### PR TITLE
feat: add save load telemetry

### DIFF
--- a/data/samples/save_sample.json
+++ b/data/samples/save_sample.json
@@ -1,0 +1,10 @@
+{
+  "player": {
+    "name": "Ada",
+    "traits": {
+      "Hubris": 0.5,
+      "Fear": 0.2
+    }
+  },
+  "scene": "end"
+}

--- a/data/samples/telemetry_sample.json
+++ b/data/samples/telemetry_sample.json
@@ -1,0 +1,17 @@
+[
+  {
+    "event": "choice",
+    "id": "door",
+    "selection": "open",
+    "tags": [
+      {
+        "trait": "Hubris",
+        "weight": 0.5
+      },
+      {
+        "trait": "Fear",
+        "weight": 0.2
+      }
+    ]
+  }
+]

--- a/docs/save_format.md
+++ b/docs/save_format.md
@@ -1,0 +1,32 @@
+# Save File Format
+
+Game state is stored as JSON. Example structure:
+
+```json
+{
+  "player": {
+    "name": "Ada",
+    "traits": {
+      "Hubris": 0.5,
+      "Fear": 0.2
+    }
+  },
+  "scene": "end"
+}
+```
+
+Telemetry output is an array of events:
+
+```json
+[
+  {
+    "event": "choice",
+    "id": "door",
+    "selection": "open",
+    "tags": [
+      {"trait": "Hubris", "weight": 0.5},
+      {"trait": "Fear", "weight": 0.2}
+    ]
+  }
+]
+```

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -4,11 +4,20 @@ This module contains the fundamental components that power the Janus RPG system.
 
 ## Components
 
-- **engine.py**: Main game loop and state management
-- **renderer.py**: Text-based UI rendering system
-- **input_handler.py**: User input processing
-- **save_system.py**: Game state persistence
-- **event_manager.py**: Event-driven architecture support
+- **engine.py** – Minimal game loop with CLI options for save/load, HUD toggle, and telemetry logging.
+- **save_system.py** – JSON-based game state persistence.
+- **telemetry.py** – Lightweight gameplay event logger.
+
+## Engine CLI
+
+```
+python src/core/engine.py [--load FILE] [--save FILE] [--no-hud] [--telemetry FILE]
+```
+
+- `--load` loads a previously saved state.
+- `--save` writes the current state in JSON format.
+- `--no-hud` suppresses the HUD display.
+- `--telemetry` records gameplay events to a JSON file.
 
 ## Design Principles
 

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -1,0 +1,72 @@
+"""Minimal engine loop with save/load, HUD toggle, and telemetry."""
+from __future__ import annotations
+
+
+import argparse
+import os
+import sys
+from typing import Any, Dict
+
+# Allow importing from project root
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from game.choice_engine import tag  # type: ignore
+from save_system import load_game, save_game
+from telemetry import Telemetry
+
+
+def default_state() -> Dict[str, Any]:
+    return {"player": {"name": "Adventurer", "traits": {}}, "scene": "intro"}
+
+
+def show_hud(state: Dict[str, Any]) -> None:
+    print("== HUD ==")
+    print(f"Player: {state['player']['name']}")
+    for trait, value in state["player"]["traits"].items():
+        print(f"  {trait}: {value}")
+    print("==========")
+
+
+def main(argv: Any = None) -> int:
+    parser = argparse.ArgumentParser(description="Janus minimal engine")
+    parser.add_argument("--load", help="Load game state from file")
+    parser.add_argument("--save", help="Save game state to file")
+    parser.add_argument("--no-hud", action="store_true", help="Disable HUD display")
+    parser.add_argument("--telemetry", help="Write telemetry events to file")
+    args = parser.parse_args(argv)
+
+    state = default_state()
+    if args.load:
+        state = load_game(args.load)
+
+    telemetry = Telemetry(args.telemetry)
+
+    if state["player"]["name"] == "Adventurer":
+        state["player"]["name"] = input("Enter your name: ") or "Adventurer"
+
+    if not args.no_hud:
+        show_hud(state)
+
+    choice = {"id": "door", "text": "Open the ancient door"}
+    choice = tag(choice, "Hubris", 0.5, "Fear", 0.2)
+    print("1.", choice["text"])
+    print("2. Walk away")
+    selection = input("Choose 1 or 2: ").strip()
+    if selection == "1":
+        for tag_info in choice["tags"]:
+            trait = tag_info["trait"]
+            state["player"]["traits"][trait] = state["player"]["traits"].get(trait, 0.0) + tag_info["weight"]
+        telemetry.log({"event": "choice", "id": "door", "selection": "open", "tags": choice["tags"]})
+    else:
+        telemetry.log({"event": "choice", "id": "door", "selection": "walk_away"})
+    state["scene"] = "end"
+
+    if args.save:
+        save_game(state, args.save)
+    telemetry.save()
+    if not args.no_hud:
+        show_hud(state)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/core/save_system.py
+++ b/src/core/save_system.py
@@ -1,0 +1,37 @@
+"""Simple JSON-based save/load utilities."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def save_game(state: Dict[str, Any], path: str) -> None:
+    """Save ``state`` to ``path`` as JSON.
+
+    Parameters
+    ----------
+    state: dict
+        Arbitrary serialisable game state.
+    path: str
+        Destination file path.
+    """
+    with open(Path(path), "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2)
+
+
+def load_game(path: str) -> Dict[str, Any]:
+    """Load game state from ``path``.
+
+    Parameters
+    ----------
+    path: str
+        Source JSON file path.
+
+    Returns
+    -------
+    dict
+        Parsed game state.
+    """
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return json.load(f)

--- a/src/core/telemetry.py
+++ b/src/core/telemetry.py
@@ -1,0 +1,23 @@
+"""Lightweight telemetry logging."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class Telemetry:
+    """Collects and writes gameplay events to JSON."""
+
+    def __init__(self, path: Optional[str] = None):
+        self.events: List[Dict[str, Any]] = []
+        self.path = Path(path) if path else None
+
+    def log(self, event: Dict[str, Any]) -> None:
+        if self.path:
+            self.events.append(event)
+
+    def save(self) -> None:
+        if self.path:
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(self.events, f, indent=2)


### PR DESCRIPTION
## Summary
- implement minimal engine with save/load, HUD toggle, and telemetry CLI options
- add JSON save system and telemetry logger utilities
- document save file format and include sample save and telemetry outputs

## Testing
- `python -m py_compile src/core/engine.py src/core/save_system.py src/core/telemetry.py src/game/choice_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_689b89f869e0832396af3173e564678e