### PR TITLE
feat: expand scenarios with decoys and high-weight choices

### DIFF
--- a/SPRINT_REPORT.md
+++ b/SPRINT_REPORT.md
@@ -1,7 +1,7 @@
 # Project Janus – Sprint Report
 
 ## Overview
-This document summarizes the work completed across eight development sprints and the current state of the Project Janus repository.
+This document summarizes the work completed across ten development sprints and the current state of the Project Janus repository.
 
 ## Sprint Accomplishments
 1. **Sprint 1 – Trait glossary and tagging API.** Introduced psychological weighting for quest choices, enabling traits to be tracked throughout gameplay.
@@ -12,6 +12,8 @@ This document summarizes the work completed across eight development sprints and
 6. **Sprint 6 – Endgame reveal library.** Added narrative templates that summarize dominant and secondary traits.
 7. **Sprint 7 – Save/load telemetry.** Integrated lightweight event logging and command-line options for save and load.
 8. **Sprint 8 – Trait balance from playtests.** Balanced trait progression using feedback and logs from playtest runs.
+9. **Sprint 9 – Repository audit and reorganization.** Consolidated directories and verified imports and documentation.
+10. **Sprint 10 – Scenario depth and decoys.** Added micro-scenes, decoy encounters, and high-weight options to obscure trait linkage.
 
 ## Repository Status
 - Source code and data are organized under clearly defined directories (`src/`, `data/`, `versions/`, etc.).

--- a/data/README.md
+++ b/data/README.md
@@ -11,7 +11,7 @@ JSON files defining quest structures, dialogue, choices, and outcomes.
 NPC definitions, personality traits, and dialogue trees.
 
 ### Scenarios (`scenarios/`)
-Psychological testing scenarios and their scoring parameters.
+Psychological testing scenarios and their scoring parameters. Includes decoy scenes and varied weighting to camouflage trait tracking.
 
 
 ### Payoffs (`payoffs/`)

--- a/data/scenarios/README.md
+++ b/data/scenarios/README.md
@@ -1,0 +1,11 @@
+# Scenario Files
+
+Act-based scene collections defining micro, mid, and pocket encounters. Each scene contains narrative text and trait-weighted choices.
+
+## Weights
+- `0.0` – decoy narrative choice
+- `0.2` – micro choice, minor signal
+- `0.5` – mid choice, moderate signal
+- `0.8` – high-impact choice
+
+Sprint 10 expands coverage with additional micro-scenes, decoys, and high-weight options across all acts to better disguise direct trait links.

--- a/data/scenarios/act1_mirrors.json
+++ b/data/scenarios/act1_mirrors.json
@@ -74,6 +74,29 @@
       ]
     },
     {
+      "scene_id": "twin_scholar",
+      "type": "micro",
+      "text": "A scholar identical to you presents a thesis claiming your life's work.",
+      "choices": [
+        {
+          "choice_id": "challenge_claim",
+          "text": "Publicly dissect their argument until they falter.",
+          "primary_trait": "Envy",
+          "primary_weight": 0.8,
+          "secondary_trait": "Hubris",
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "cede_floor",
+          "text": "Applaud politely and leave the hall.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
       "scene_id": "confessing_mirror",
       "type": "micro",
       "text": "A mirror asks what flaw you hide.",
@@ -88,7 +111,7 @@
         },
         {
           "choice_id": "praise_reflection",
-          "text": "Praise your reflection's perfection.",
+          "text": "Offer a self-assured smile to the mirror.",
           "primary_trait": "Hubris",
           "primary_weight": 0.2,
           "secondary_trait": "Deception",
@@ -174,6 +197,29 @@
       ]
     },
     {
+      "scene_id": "echo_parlor",
+      "type": "micro",
+      "text": "Empty frames hang in a parlor, reflecting only echoes.",
+      "choices": [
+        {
+          "choice_id": "hum_a_tune",
+          "text": "Hum a fragment of song and listen for an answer.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "close_door",
+          "text": "Close the parlor door and keep the silence.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
       "scene_id": "labyrinth_library",
       "type": "mid",
       "text": "Shelves twist into a labyrinth of forgotten knowledge.",
@@ -199,6 +245,29 @@
           "text": "Browse aimlessly then leave the maze unchanged.",
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
+      "scene_id": "phantom_mentor",
+      "type": "micro",
+      "text": "A phantom mentor offers to erase one mistake from your past.",
+      "choices": [
+        {
+          "choice_id": "rewrite_memory",
+          "text": "Accept and choose a memory to rewrite.",
+          "primary_trait": "Deception",
+          "primary_weight": 0.2,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "decline_offer",
+          "text": "Decline, fearing who you might become without it.",
+          "primary_trait": "Fear",
+          "primary_weight": 0.2,
           "secondary_trait": null,
           "secondary_weight": 0.0
         }

--- a/data/scenarios/act2_beasts.json
+++ b/data/scenarios/act2_beasts.json
@@ -9,14 +9,14 @@
       "type": "micro",
       "text": "A boar stumbles before you, its flank pierced by spears.",
       "choices": [
-        {
-          "choice_id": "finish_boar",
-          "text": "Drive in another spear to end its struggle.",
-          "primary_trait": "Wrath",
-          "primary_weight": 0.1,
-          "secondary_trait": "Impulsivity",
-          "secondary_weight": 0.1
-        },
+          {
+            "choice_id": "finish_boar",
+            "text": "Press another spear in to still its thrashing.",
+            "primary_trait": "Wrath",
+            "primary_weight": 0.1,
+            "secondary_trait": "Impulsivity",
+            "secondary_weight": 0.1
+          },
         {
           "choice_id": "bind_wound",
           "text": "Kneel and bind its wound despite the gore.",
@@ -32,14 +32,14 @@
       "type": "micro",
       "text": "Iron bars groan as a lion hurls itself against them.",
       "choices": [
-        {
-          "choice_id": "tighten_bars",
-          "text": "Wedge new bolts to tighten its cage.",
-          "primary_trait": "Control",
-          "primary_weight": 0.2,
-          "secondary_trait": "Rigidity",
-          "secondary_weight": 0.1
-        },
+          {
+            "choice_id": "tighten_bars",
+            "text": "Wedge new bolts with deliberate calm.",
+            "primary_trait": "Control",
+            "primary_weight": 0.2,
+            "secondary_trait": "Rigidity",
+            "secondary_weight": 0.1
+          },
         {
           "choice_id": "open_gate",
           "text": "Swing the gate wide and step back.",
@@ -143,6 +143,52 @@
       ]
     },
     {
+      "scene_id": "jealous_raven",
+      "type": "micro",
+      "text": "A raven guards a glittering trove stolen from travelers.",
+      "choices": [
+        {
+          "choice_id": "snatch_treasure",
+          "text": "Grab the brightest jewel while the bird preens.",
+          "primary_trait": "Envy",
+          "primary_weight": 0.8,
+          "secondary_trait": "Avarice",
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "leave_treasure",
+          "text": "Leave the hoard untouched and walk on.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
+      "scene_id": "sleeping_dragon",
+      "type": "micro",
+      "text": "A dragon slumbers atop cold embers, smoke curling from its nostrils.",
+      "choices": [
+        {
+          "choice_id": "watch_slumber",
+          "text": "Watch quietly until its breathing steadies.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "tiptoe_past",
+          "text": "Ease past on silent feet, disturbing nothing.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
       "scene_id": "verdict_pit",
       "type": "mid",
       "text": "A captured chimera kneels in a pit as the crowd roars for judgment.",
@@ -180,7 +226,7 @@
       "choices": [
         {
           "choice_id": "whip_beasts",
-          "text": "Crack a whip to assert brutal order.",
+          "text": "Snap a whip to force uneasy order.",
           "primary_trait": "Wrath",
           "primary_weight": 0.4,
           "secondary_trait": "Cynicism",
@@ -199,6 +245,29 @@
           "text": "Dump all the food and watch them feast.",
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
+      "scene_id": "blood_vow",
+      "type": "micro",
+      "text": "A beast extends a claw, demanding a blood oath for safe passage.",
+      "choices": [
+        {
+          "choice_id": "seal_oath",
+          "text": "Prick your finger and seal the pact.",
+          "primary_trait": "Control",
+          "primary_weight": 0.2,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "refuse_oath",
+          "text": "Refuse and circle the long way around.",
+          "primary_trait": "Fear",
+          "primary_weight": 0.2,
           "secondary_trait": null,
           "secondary_weight": 0.0
         }

--- a/data/scenarios/act3_whispers.json
+++ b/data/scenarios/act3_whispers.json
@@ -97,6 +97,29 @@
       ]
     },
     {
+      "scene_id": "storm_door",
+      "type": "micro",
+      "text": "A door pulses with light and shadow as a storm rages behind it.",
+      "choices": [
+        {
+          "choice_id": "open_anyway",
+          "text": "Throw it wide regardless of what mood waits beyond.",
+          "primary_trait": "Moodiness",
+          "primary_weight": 0.5,
+          "secondary_trait": "Impulsivity",
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "walk_away",
+          "text": "Let the storm howl without you.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
       "scene_id": "luring_key",
       "type": "micro",
       "text": "A key dangles from a thread, whispering of the chest it fits.",
@@ -112,6 +135,29 @@
         {
           "choice_id": "leave_key",
           "text": "Let it sway and continue down the hall.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
+      "scene_id": "envy_shrine",
+      "type": "micro",
+      "text": "A shrine displays names of rivals basking in unearned glory.",
+      "choices": [
+        {
+          "choice_id": "deface_names",
+          "text": "Scratch your own name over theirs.",
+          "primary_trait": "Envy",
+          "primary_weight": 0.8,
+          "secondary_trait": "Hubris",
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "light_candle",
+          "text": "Light a candle and move on.",
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
           "secondary_trait": null,
@@ -174,13 +220,36 @@
       ]
     },
     {
+      "scene_id": "whistling_chasm",
+      "type": "micro",
+      "text": "Wind whistles up from a chasm, carrying stray whispers.",
+      "choices": [
+        {
+          "choice_id": "toss_pebble",
+          "text": "Toss a pebble and wait for the distant clink.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "listen_wind",
+          "text": "Lean close and listen until the wind stills.",
+          "primary_trait": "Apathy",
+          "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
       "scene_id": "whisper_court",
       "type": "mid",
       "text": "In a quiet court, accusations flow like wine but never above a murmur.",
       "choices": [
         {
           "choice_id": "spread_rumor",
-          "text": "Add your own whisper to tilt the verdict.",
+          "text": "Let slip a half-truth to tilt the verdict.",
           "primary_trait": "Deception",
           "primary_weight": 0.5,
           "secondary_trait": "Cynicism",
@@ -199,6 +268,29 @@
           "text": "Hear every argument and offer none of your own.",
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
+          "secondary_trait": null,
+          "secondary_weight": 0.0
+        }
+      ]
+    },
+    {
+      "scene_id": "tempting_contract",
+      "type": "micro",
+      "text": "A contract appears in your hand, promising all you desire at an unnamed cost.",
+      "choices": [
+        {
+          "choice_id": "sign_name",
+          "text": "Sign quickly before doubt returns.",
+          "primary_trait": "Deception",
+          "primary_weight": 0.2,
+          "secondary_trait": "Avarice",
+          "secondary_weight": 0.0
+        },
+        {
+          "choice_id": "tear_contract",
+          "text": "Tear it up and let the pieces scatter.",
+          "primary_trait": "Control",
+          "primary_weight": 0.2,
           "secondary_trait": null,
           "secondary_weight": 0.0
         }


### PR DESCRIPTION
## Summary
- add Envy and Moodiness coverage plus decoy scenes across all acts
- document scenario weighting and update sprint report
- tweak existing choices to better conceal trait mapping

## Testing
- `python -m json.tool data/scenarios/act1_mirrors.json`
- `python -m json.tool data/scenarios/act2_beasts.json`
- `python -m json.tool data/scenarios/act3_whispers.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b95bda23c8323b1bc008b9048a223