### PR TITLE
Add endgame reveal system with tests

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -3,8 +3,8 @@
 Core engine entry point and reusable modules.
 
 ## Components
-- **engine.py** – Minimal game loop with CLI options for save/load, HUD toggle, and telemetry logging.
-- **modules/** – Reusable engine modules (`tagging.py`, `save_system.py`, `telemetry.py`).
+- **engine.py** – Minimal game loop with CLI options for save/load, HUD toggle, telemetry logging, and endgame trait reveal.
+- **modules/** – Reusable engine modules (`tagging.py`, `save_system.py`, `telemetry.py`, `reveal.py`).
 
 ## Engine CLI
 

--- a/src/engine.py
+++ b/src/engine.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 from typing import Any, Dict
 
 from modules.tagging import tag
 from modules.save_system import load_game, save_game
 from modules.telemetry import Telemetry
+from modules.reveal import load_reveals, pick_reveal
 
 
 def default_state() -> Dict[str, Any]:
@@ -60,6 +62,12 @@ def main(argv: Any = None) -> int:
     telemetry.save()
     if not args.no_hud:
         show_hud(state)
+
+    reveals_path = Path(__file__).resolve().parent.parent / "data" / "payoffs" / "endgame_reveals.json"
+    reveal_data = load_reveals(reveals_path)
+    reveal = pick_reveal(state["player"]["traits"], reveal_data)
+    print("\n== Final Reflection ==")
+    print(reveal["text"])
     return 0
 
 

--- a/src/modules/README.md
+++ b/src/modules/README.md
@@ -6,3 +6,4 @@ Reusable components supporting the core engine.
 - `tagging.py` – Trait tagging utilities for player choices.
 - `save_system.py` – JSON-based save/load helpers.
 - `telemetry.py` – Lightweight gameplay event logging.
+- `reveal.py` – Endgame trait reveal selection utilities.

--- a/src/modules/reveal.py
+++ b/src/modules/reveal.py
@@ -1,0 +1,58 @@
+"""Endgame trait reveal helpers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_reveals(path: str | Path) -> Dict[str, Any]:
+    """Load reveal definitions from ``path``.
+
+    Parameters
+    ----------
+    path: str | Path
+        Location of the ``endgame_reveals.json`` file.
+    """
+    with open(Path(path), "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def top_traits(traits: Dict[str, float], count: int = 3) -> List[str]:
+    """Return the top ``count`` traits sorted by weight."""
+    return [t for t, _ in sorted(traits.items(), key=lambda i: i[1], reverse=True)[:count]]
+
+
+def pick_reveal(traits: Dict[str, float], reveals: Dict[str, Any]) -> Dict[str, str]:
+    """Select a reveal based on the player's top two traits.
+
+    Parameters
+    ----------
+    traits: dict
+        Mapping of trait names to accumulated weights.
+    reveals: dict
+        Reveal data loaded via :func:`load_reveals`.
+
+    Returns
+    -------
+    dict
+        Dictionary with ``id`` and ``text`` keys for the chosen reveal.
+    """
+    top = top_traits(traits, 2)
+    if len(top) < 2 or traits[top[0]] == traits[top[1]]:
+        fallback = reveals["neutral_fallback"]
+        return {"id": fallback["id"], "text": fallback["template"]}
+
+    primary, secondary = top
+    for tpl in reveals["reveal_templates"]:
+        if tpl["primary_trait"] == primary and tpl["secondary_trait"] == secondary:
+            text = tpl["template"].format(
+                primary_trait=primary,
+                secondary_trait=secondary,
+                primary_metaphor=reveals["trait_metaphors"][primary],
+                secondary_metaphor=reveals["trait_metaphors"][secondary],
+            )
+            return {"id": tpl["id"], "text": text}
+
+    fallback = reveals["neutral_fallback"]
+    return {"id": fallback["id"], "text": fallback["template"]}

--- a/tests/test_reveal.py
+++ b/tests/test_reveal.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from modules.reveal import load_reveals, pick_reveal
+
+REVEALS_PATH = Path(__file__).resolve().parents[1] / "data" / "payoffs" / "endgame_reveals.json"
+
+
+def test_hubris_control_reveal():
+    reveals = load_reveals(REVEALS_PATH)
+    text = pick_reveal({"Hubris": 1.0, "Control": 0.5}, reveals)["text"]
+    assert "Hubris" in text and "Control" in text
+
+
+def test_avarice_wrath_reveal():
+    reveals = load_reveals(REVEALS_PATH)
+    text = pick_reveal({"Avarice": 1.2, "Wrath": 0.7}, reveals)["text"]
+    assert "Avarice" in text and "Wrath" in text
+
+
+def test_tied_traits_use_fallback():
+    reveals = load_reveals(REVEALS_PATH)
+    text = pick_reveal({"Hubris": 0.5, "Avarice": 0.5}, reveals)["text"]
+    assert "glass offers no single emblem" in text


### PR DESCRIPTION
## Summary
- add module to compute endgame trait reveals
- integrate reveal display into engine and docs
- verify reveal selection with simulated playthrough tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b9a9687a483239f34077b8e8ab8bf