### PR TITLE
feat: prepare alpha beta test build

### DIFF
--- a/SPRINT_REPORT.md
+++ b/SPRINT_REPORT.md
@@ -1,7 +1,7 @@
 # Project Janus – Sprint Report
 
 ## Overview
-This document summarizes the work completed across ten development sprints and the current state of the Project Janus repository.
+This document summarizes the work completed across twelve development sprints and the current state of the Project Janus repository.
 
 ## Sprint Accomplishments
 1. **Sprint 1 – Trait glossary and tagging API.** Introduced psychological weighting for quest choices, enabling traits to be tracked throughout gameplay.
@@ -14,6 +14,8 @@ This document summarizes the work completed across ten development sprints and t
 8. **Sprint 8 – Trait balance from playtests.** Balanced trait progression using feedback and logs from playtest runs.
 9. **Sprint 9 – Repository audit and reorganization.** Consolidated directories and verified imports and documentation.
 10. **Sprint 10 – Scenario depth and decoys.** Added micro-scenes, decoy encounters, and high-weight options to obscure trait linkage.
+11. **Sprint 11 – End-to-end trait reveal pass.** Verified the full trait-tracking loop and ensured reveal coverage for all trait constellations.
+12. **Sprint 12 – Alpha/Beta test setup.** Introduced last-choice HUD details, expanded telemetry logging, and added a packaging script for tester builds.
 
 ## Repository Status
 - Source code and data are organized under clearly defined directories (`src/`, `data/`, `versions/`, etc.).
@@ -21,6 +23,6 @@ This document summarizes the work completed across ten development sprints and t
 - Playtest artifacts and trait payoff libraries are stored under `data/` for iterative tuning.
 
 ## Next Steps
+- Gather feedback from alpha/beta testers.
 - Expand scenario library and refine psychological mappings.
 - Continue playtesting to validate trait balance.
-- Prepare beta release build once content is finalized.

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,6 +8,20 @@ Production deployment configuration and release management.
 3. Include necessary data files
 4. Create distribution packages
 
+### Alpha/Beta Build
+
+Use the helper script to bundle a tester-ready archive:
+
+```
+python deployment/build_alpha.py
+```
+
+The script outputs `dist/janus_alpha.zip` containing `src/` and `data/`. Testers can unzip it and run the engine:
+
+```
+python src/engine.py --telemetry log.json
+```
+
 ## Release Management
 - Semantic versioning
 - Release notes generation

--- a/deployment/build_alpha.py
+++ b/deployment/build_alpha.py
@@ -1,0 +1,25 @@
+"""Package Janus for alpha/beta testing."""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DIST = ROOT / "dist"
+
+
+def build() -> None:
+    """Create a zip archive with source and data files."""
+    DIST.mkdir(exist_ok=True)
+    build_dir = DIST / "janus"
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    shutil.copytree(ROOT / "src", build_dir / "src")
+    shutil.copytree(ROOT / "data", build_dir / "data")
+    shutil.copy(ROOT / "README.md", build_dir / "README.md")
+    shutil.make_archive(str(DIST / "janus_alpha"), "zip", build_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    build()
+    print("Created dist/janus_alpha.zip")

--- a/src/README.md
+++ b/src/README.md
@@ -3,7 +3,7 @@
 Core engine entry point and reusable modules.
 
 ## Components
-- **engine.py** – Minimal game loop with CLI options for save/load, HUD toggle, telemetry logging, and endgame trait reveal.
+- **engine.py** – Minimal game loop with save/load, HUD toggle, telemetry logging, and endgame trait reveal. The HUD displays current trait totals and details of the last choice.
 - **modules/** – Reusable engine modules (`tagging.py`, `save_system.py`, `telemetry.py`, `reveal.py`).
 
 ## Engine CLI
@@ -14,7 +14,7 @@ python src/engine.py [--load FILE] [--save FILE] [--no-hud] [--telemetry FILE]
 - `--load` loads a previously saved state.
 - `--save` writes the current state in JSON format.
 - `--no-hud` suppresses the HUD display.
-- `--telemetry` records gameplay events to a JSON file.
+- `--telemetry` records choice events (ID and trait weights) to a JSON file.
 
 ## Design Principles
 - Modular and extensible architecture

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import json
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from modules.telemetry import Telemetry
+
+
+def test_telemetry_logs_choice(tmp_path):
+    log_file = tmp_path / "log.json"
+    tel = Telemetry(str(log_file))
+    tel.log({
+        "event": "choice",
+        "id": "door",
+        "selection": "open",
+        "primary_trait": "Hubris",
+        "primary_weight": 0.5,
+        "secondary_trait": "Fear",
+        "secondary_weight": 0.2,
+    })
+    tel.save()
+    data = json.loads(log_file.read_text())
+    assert data[0]["primary_trait"] == "Hubris"
+    assert data[0]["secondary_weight"] == 0.2


### PR DESCRIPTION
## Summary
- track last choice in the HUD and log detailed trait weights
- add build script and deployment docs for alpha/beta tester package
- update sprint report and docs, plus test telemetry logging

## Testing
- `python deployment/build_alpha.py`
- `python src/engine.py --telemetry temp_log.json --save temp_save.json` (name: TestPlayer, choice: 1)
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b9c27022c8323803863214b643304