### PR TITLE
docs: update sprint report and readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ At the end of your quest, you receive your Hero's Chronicle:
 - Covert psychological scoring system
 - Replayable scenarios with different personality outcomes
 - Modular design for adding new quests, dilemmas, and scoring frameworks
+- Interactive testing dashboard for visualising trait progression
 
 ## Project Structure
 
@@ -28,6 +29,9 @@ Structured game data separated from code for easy modification and localization.
 Engine entry point and reusable modules.
 - `engine.py` – main game loop
 - `modules/` – trait tagging, save system, telemetry utilities
+- `cli/` – command-line entry points and helpers
+- `dashboard/` – Dash-powered simulation dashboard
+- `testing/` – automated test harness and policies
 
 ### 📁 `/versions/` - Development Iterations
 Version-specific implementations showing project evolution. See [`versions/README.md`](versions/README.md) for details on each milestone.
@@ -63,6 +67,10 @@ Telemetry logs, test results, and other generated content. [See outputs README](
 4. **Explore the Code**: Review `/src/` modules to understand the architecture.
 5. **Read the Docs**: Check `/docs/` for comprehensive design and technical documentation.
 6. **Run Tests**: Execute test scripts in `/tests/` to verify system functionality.
+7. **Launch the Testing Dashboard**:
+   ```bash
+   python src/dashboard/run_dashboard.py
+   ```
 
 ## Vision
 Future versions may expand into adaptive NPC behavior, multiplayer "party dynamics" profiling, and ethically designed research modules for psychological studies.

--- a/SPRINT_REPORT.md
+++ b/SPRINT_REPORT.md
@@ -1,7 +1,7 @@
 # Project Janus – Sprint Report
 
 ## Overview
-This document summarizes the work completed across twelve development sprints and the current state of the Project Janus repository.
+This document summarizes the work completed across thirteen development sprints and the current state of the Project Janus repository.
 
 ## Sprint Accomplishments
 1. **Sprint 1 – Trait glossary and tagging API.** Introduced psychological weighting for quest choices, enabling traits to be tracked throughout gameplay.
@@ -16,6 +16,7 @@ This document summarizes the work completed across twelve development sprints an
 10. **Sprint 10 – Scenario depth and decoys.** Added micro-scenes, decoy encounters, and high-weight options to obscure trait linkage.
 11. **Sprint 11 – End-to-end trait reveal pass.** Verified the full trait-tracking loop and ensured reveal coverage for all trait constellations.
 12. **Sprint 12 – Alpha/Beta test setup.** Introduced last-choice HUD details, expanded telemetry logging, and added a packaging script for tester builds.
+13. **Sprint 13 – Testing dashboard and control panel.** Delivered a Dash-powered dashboard for running archetype simulations and visualising trait progression.
 
 ## Repository Status
 - Source code and data are organized under clearly defined directories (`src/`, `data/`, `versions/`, etc.).
@@ -26,3 +27,4 @@ This document summarizes the work completed across twelve development sprints an
 - Gather feedback from alpha/beta testers.
 - Expand scenario library and refine psychological mappings.
 - Continue playtesting to validate trait balance.
+- Iterate on the testing dashboard and integrate future codex features.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ For quick access to key information:
 - **Save Format**: `technical/save_format.md`
 - **Latest Playtest**: `testing/sprint8_playtest_report.md`
 - **Development Status**: `development/commission_sprints.md`
+- **Testing Dashboard**: `development/dashboard.md`
 
 ## Writing Guidelines
 

--- a/src/README.md
+++ b/src/README.md
@@ -5,6 +5,9 @@ Core engine entry point and reusable modules.
 ## Components
 - **engine.py** – Minimal game loop with save/load, HUD toggle, telemetry logging, and endgame trait reveal. The HUD displays current trait totals and details of the last choice.
 - **modules/** – Reusable engine modules (`tagging.py`, `save_system.py`, `telemetry.py`, `reveal.py`).
+- **cli/** – Command-line helpers and entry points.
+- **dashboard/** – Dash-powered interface for running simulation policies and visualising trait progression.
+- **testing/** – Harness utilities, policies, and metrics for automated runs.
 
 ## Engine CLI
 


### PR DESCRIPTION
## Summary
- Extend sprint report with new testing dashboard milestone and upcoming plans
- Document dashboard, CLI, and testing modules across project and source readmes
- Link testing dashboard instructions in docs overview

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c965fd25c83239e51ca0520de1923