### PR TITLE
docs: update dashboard guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ At the end of your quest, you receive your Hero's Chronicle:
 - Covert psychological scoring system
 - Replayable scenarios with different personality outcomes
 - Modular design for adding new quests, dilemmas, and scoring frameworks
-- Interactive testing dashboard for visualising trait progression
+- Dash-powered testing dashboard for running simulations and visualising trait progression
 
 ## Project Structure
 
@@ -71,6 +71,7 @@ Telemetry logs, test results, and other generated content. [See outputs README](
    ```bash
    python src/dashboard/run_dashboard.py
    ```
+   Use the web UI to choose a policy, run simulations, and view trait charts.
 
 ## Vision
 Future versions may expand into adaptive NPC behavior, multiplayer "party dynamics" profiling, and ethically designed research modules for psychological studies.

--- a/docs/development/dashboard.md
+++ b/docs/development/dashboard.md
@@ -4,7 +4,7 @@ An interactive dashboard for running Janus simulation policies and visualising t
 
 ## Setup
 
-Install the required packages:
+The dashboard relies on Dash and Plotly. Dependencies are installed automatically on first launch, but you can pre-install them:
 
 ```bash
 pip install dash plotly
@@ -18,4 +18,8 @@ Start the dashboard from the repository root:
 python src/dashboard/run_dashboard.py
 ```
 
-A browser window will open with controls to select a policy and execute a run.  Results are saved under `data/test_results/` for later inspection.
+### Features
+
+- Choose between built-in policies and run simulations with a click
+- View line charts of trait progression and bar charts of final scores
+- Each run is saved under `data/test_results/` for later inspection


### PR DESCRIPTION
## Summary
- Document dashboard upgrade in development docs
- Mention new dash-powered testing dashboard features in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ca358c6008323ad60a49b030e82fc