### PR TITLE
docs: refresh dashboard and calibration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ At the end of your quest, you receive your Hero's Chronicle:
 - Covert psychological scoring system
 - Replayable scenarios with different personality outcomes
 - Modular design for adding new quests, dilemmas, and scoring frameworks
-- Dash-powered testing dashboard for running simulations and visualising trait progression
+- Dash-powered testing dashboard with calibration monitor for tuning policy multipliers and visualising trait progression
+- Bounded calibration tools for optimizing policy multipliers and generating configuration snapshots
 
 ## Project Structure
 
@@ -30,7 +31,8 @@ Engine entry point and reusable modules.
 - `engine.py` – main game loop
 - `modules/` – trait tagging, save system, telemetry utilities
 - `cli/` – command-line entry points and helpers
-- `dashboard/` – Dash-powered simulation dashboard
+- `dashboard/` – Dash-powered simulation dashboard and calibration interface
+- `calibrator/` – tuning utilities and optimizer for policy multipliers
 - `testing/` – automated test harness and policies
 
 ### 📁 `/versions/` - Development Iterations
@@ -71,7 +73,7 @@ Telemetry logs, test results, and other generated content. [See outputs README](
    ```bash
    python src/dashboard/run_dashboard.py
    ```
-   Use the web UI to choose a policy, run simulations, and view trait charts.
+   Use the web UI to choose a policy, run simulations, view trait charts, and adjust calibration settings in the **Calibration** tab.
 
 ## Vision
 Future versions may expand into adaptive NPC behavior, multiplayer "party dynamics" profiling, and ethically designed research modules for psychological studies.

--- a/SPRINT_REPORT.md
+++ b/SPRINT_REPORT.md
@@ -1,7 +1,7 @@
 # Project Janus – Sprint Report
 
 ## Overview
-This document summarizes the work completed across thirteen development sprints and the current state of the Project Janus repository.
+This document summarizes the work completed across sixteen development sprints and the current state of the Project Janus repository.
 
 ## Sprint Accomplishments
 1. **Sprint 1 – Trait glossary and tagging API.** Introduced psychological weighting for quest choices, enabling traits to be tracked throughout gameplay.
@@ -17,6 +17,9 @@ This document summarizes the work completed across thirteen development sprints 
 11. **Sprint 11 – End-to-end trait reveal pass.** Verified the full trait-tracking loop and ensured reveal coverage for all trait constellations.
 12. **Sprint 12 – Alpha/Beta test setup.** Introduced last-choice HUD details, expanded telemetry logging, and added a packaging script for tester builds.
 13. **Sprint 13 – Testing dashboard and control panel.** Delivered a Dash-powered dashboard for running archetype simulations and visualising trait progression.
+14. **Sprint 14 – Data ingestion & analytics baseline.** Added canonical trait mapping, run ingestion scripts, and baseline calibration metrics.
+15. **Sprint 15 – Calibrator & optimization.** Implemented bounded calibration utilities, optimizer, and configuration snapshot output.
+16. **Sprint 16 – Dashboard "Personality Mixer."** Integrated a calibration tab with live slider readouts for policy multipliers and master controls.
 
 ## Repository Status
 - Source code and data are organized under clearly defined directories (`src/`, `data/`, `versions/`, etc.).
@@ -28,3 +31,4 @@ This document summarizes the work completed across thirteen development sprints 
 - Expand scenario library and refine psychological mappings.
 - Continue playtesting to validate trait balance.
 - Iterate on the testing dashboard and integrate future codex features.
+- Refine calibration workflow and analytics pipeline.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ For quick access to key information:
 - **Save Format**: `technical/save_format.md`
 - **Latest Playtest**: `testing/sprint8_playtest_report.md`
 - **Development Status**: `development/commission_sprints.md`
-- **Testing Dashboard**: `development/dashboard.md`
+ - **Testing Dashboard & Calibration Monitor**: `development/dashboard.md`
 
 ## Writing Guidelines
 

--- a/docs/development/dashboard.md
+++ b/docs/development/dashboard.md
@@ -1,6 +1,6 @@
-# Testing Dashboard
+# Testing Dashboard & Calibration Monitor
 
-An interactive dashboard for running Janus simulation policies and visualising trait progression.
+An interactive dashboard for running Janus simulation policies, visualising trait progression, and experimenting with calibration settings.
 
 ## Setup
 
@@ -21,5 +21,11 @@ python src/dashboard/run_dashboard.py
 ### Features
 
 - Choose between built-in policies and run simulations with a click
-- View line charts of trait progression and bar charts of final scores
+- Tabbed charts for trait progression, final scores, and decision trees
+- Quick stats summarising recent runs
+- Dedicated "Calibration" tab with a mixer interface for policy multipliers
 - Each run is saved under `data/test_results/` for later inspection
+
+### Calibration Monitor
+
+Open the **Calibration** tab to access the experimental "Personality Mixer." Use the sliders to adjust policy multipliers and master controls such as decay, anti-streak, and epsilon. Readouts update in real time while providing a foundation for future calibration tooling.

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,8 @@ Core engine entry point and reusable modules.
 - **engine.py** – Minimal game loop with save/load, HUD toggle, telemetry logging, and endgame trait reveal. The HUD displays current trait totals and details of the last choice.
 - **modules/** – Reusable engine modules (`tagging.py`, `save_system.py`, `telemetry.py`, `reveal.py`).
 - **cli/** – Command-line helpers and entry points.
-- **dashboard/** – Dash-powered interface for running simulation policies and visualising trait progression.
+- **dashboard/** – Dash-powered interface for running simulation policies, visualising trait progression, and experimenting with calibration.
+- **calibrator/** – Tools for applying policy multipliers and optimizing configuration snapshots.
 - **testing/** – Harness utilities, policies, and metrics for automated runs.
 
 ## Engine CLI


### PR DESCRIPTION
## Summary
- document calibration monitor and policy tuning features across docs
- add sprints 14-16 covering analytics baseline and calibration upgrades
- link calibration monitor from quick reference and source tree docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ce101ec408323bd7fb02c0bd674fa