### PR TITLE
Expand choice architecture with trait tagging

### DIFF
--- a/docs/development/commission_sprints_complete.md
+++ b/docs/development/commission_sprints_complete.md
@@ -614,3 +614,14 @@ Deliverables:
 Definition of Done
 Mixer renders within the dashboard and slider readouts update via callbacks.
 
+Sprint 18 – Expanded Choice Architecture
+Goal: Move beyond binary decision-making to offer richer, psychologically distinct options.
+
+Deliverables:
+- Choice Framework Upgrade — support for 3–4 options per scene.
+- Option Tagging Integration — each choice tagged to one or more existing psychological traits.
+- Illusion of Choice Mechanic — minimum 1 "locked fate" option per act for narrative realism.
+
+Definition of Done
+≥80% of core scenes have ≥3 options; all options carry trait tags compatible with existing scoring engine.
+

--- a/docs/development/commission_sprints_todo.md
+++ b/docs/development/commission_sprints_todo.md
@@ -13,21 +13,6 @@
 
 ---
 
-## **Sprint 18 – Expanded Choice Architecture**
-
-**Objective:** Move beyond binary decision-making to offer richer, psychologically distinct options.
-**Rationale:** Current scenes default to two polar choices; this restricts nuance and weakens psychological inference.
-**Deliverables:**
-
-* **Choice Framework Upgrade** — support for 3–4 options per scene.
-* **Option Tagging Integration** — each choice tagged to one or more *existing* psychological traits.
-* **Illusion of Choice Mechanic** — minimum 1 “locked fate” option per act for narrative realism.
-  **Success Metrics:**
-* ≥80% of core scenes have ≥3 options.
-* All options carry trait tags compatible with existing scoring engine.
-
----
-
 ## **Sprint 19 – Psychological Payoff System Upgrade**
 
 **Objective:** Replace vague ending text with a concrete, data-driven psychological profile delivered in narrative form.


### PR DESCRIPTION
## Summary
- Allow scenes to append locked fate options and auto-fill to at least three choices.
- Integrate canonical trait tagging for choices and update telemetry logging.
- Move commission sprint 18 to completed docs.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d02533d548323a6fd98a4429be7f5