### PR TITLE
docs: refresh project documentation

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -22,7 +22,10 @@ Janus/
 │   ├── characters/             # Character data and NPCs
 │   ├── scenarios/              # Psychological scenarios
 │   ├── payoffs/                # Trait payoff templates
-│   └── playtests/              # Logs and feedback artifacts
+│   ├── playtests/              # Logs and feedback artifacts
+│   ├── derived/                # Aggregated run metrics
+│   ├── samples/                # Example save and telemetry files
+│   └── test_results/           # Outputs from automated test runs
 ├── tests/                      # Testing scripts
 └── docs/                       # Documentation
 ```
@@ -62,6 +65,9 @@ Game content is separated from code in the `data/` directory:
 - **Scenarios**: Psychological testing scenarios
 - **Payoffs**: Trait-based payoff templates
 - **Playtests**: Logs and survey results
+- **Derived**: Aggregated run metrics
+- **Samples**: Example save and telemetry files
+- **Test Results**: JSON outputs from automated test runs
 
 ## 🚀 Getting Started
 

--- a/data/README.md
+++ b/data/README.md
@@ -21,6 +21,21 @@ Includes:
 - `midgame.json` – micro payoffs and mid-scene forks keyed to traits.
 - `endgame_reveals.json` – 3×3 trait grid of endgame reveal templates with neutral fallback.
 
+### Playtests (`playtests/`)
+Logs and survey results from playtest sessions used for calibration and user studies.
+
+### Derived (`derived/`)
+Aggregated run metrics and processed outputs generated from gameplay sessions.
+
+### Samples (`samples/`)
+Example save files and telemetry logs for reference and testing.
+
+### Test Results (`test_results/`)
+JSON outputs from automated test runs and batch simulations.
+
+### Dashboard Config (`dashboard_config.json`)
+Default configuration file for the developer dashboard.
+
 
 ## Format Guidelines
 - Use JSON for structured data

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,21 @@
 # Testing Suite
 
-Placeholder for future tests of the Janus project.
+Automated tests verify engine behavior, scoring algorithms, telemetry logging, and calibration utilities.
+
+## Structure
+- `test_canonical.py` – ensures narrative flows match golden records.
+- `test_calibrator_bounds.py` – validates calibrator parameter bounds.
+- `test_ingest_schema.py` – checks input schema consistency.
+- `test_optimizer_objective.py` – verifies optimization objective calculations.
+- `test_reveal.py` – tests trait-based reveal messages.
+- `test_run_output.py` – confirms engine run outputs.
+- `test_scoring.py` – validates trait scoring logic.
+- `test_telemetry.py` – verifies telemetry capture and storage.
+
+Supporting directories:
+- `goldens/` – expected outputs for canonical tests.
+- `config/` – configuration files for test runs.
+- `reports/` – latest test suite reports.
 
 ## Running Tests
 ```bash


### PR DESCRIPTION
## Summary
- document additional data subdirectories and dashboard config
- describe existing test modules and supporting directories
- update project structure overview with new data folders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d06d1061483239441705530ff5623