### PR TITLE
feat: add stateful story continuity

### DIFF
--- a/data/scenarios/act1_mirrors.json
+++ b/data/scenarios/act1_mirrors.json
@@ -15,7 +15,9 @@
           "primary_trait": "Impulsivity",
           "primary_weight": 0.2,
           "secondary_trait": "Moodiness",
-          "secondary_weight": 0.1
+          "secondary_weight": 0.1,
+          "set_flag": "mirror",
+          "flag_value": "disturbed"
         },
         {
           "choice_id": "wait_silently",
@@ -23,7 +25,9 @@
           "primary_trait": "Rigidity",
           "primary_weight": 0.2,
           "secondary_trait": null,
-          "secondary_weight": 0.0
+          "secondary_weight": 0.0,
+          "set_flag": "mirror",
+          "flag_value": "observed"
         }
       ]
     },

--- a/data/scenarios/act2_beasts.json
+++ b/data/scenarios/act2_beasts.json
@@ -15,7 +15,9 @@
             "primary_trait": "Wrath",
             "primary_weight": 0.1,
             "secondary_trait": "Impulsivity",
-            "secondary_weight": 0.1
+            "secondary_weight": 0.1,
+            "set_flag": "beast",
+            "flag_value": "slain"
           },
         {
           "choice_id": "bind_wound",
@@ -23,7 +25,9 @@
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
           "secondary_trait": null,
-          "secondary_weight": 0.0
+          "secondary_weight": 0.0,
+          "set_flag": "beast",
+          "flag_value": "spared"
         }
       ],
       "callbacks": [

--- a/data/scenarios/act3_whispers.json
+++ b/data/scenarios/act3_whispers.json
@@ -107,7 +107,9 @@
           "primary_trait": "Moodiness",
           "primary_weight": 0.5,
           "secondary_trait": "Impulsivity",
-          "secondary_weight": 0.0
+          "secondary_weight": 0.0,
+          "set_flag": "storm",
+          "flag_value": "entered"
         },
         {
           "choice_id": "walk_away",
@@ -115,7 +117,9 @@
           "primary_trait": "Apathy",
           "primary_weight": 0.0,
           "secondary_trait": null,
-          "secondary_weight": 0.0
+          "secondary_weight": 0.0,
+          "set_flag": "storm",
+          "flag_value": "avoided"
         }
       ]
     },

--- a/src/modules/state_manager.py
+++ b/src/modules/state_manager.py
@@ -1,24 +1,33 @@
 from __future__ import annotations
 
-"""Persistent state flag manager."""
+"""Persistent state manager tracking flags and trait scores."""
 from typing import Any, Dict
 
 
 class StateManager:
-    """Centralized storage and retrieval for game state flags."""
+    """Centralized storage and retrieval for game state."""
 
     def __init__(self, state: Dict[str, Any]):
         self.state = state
-        self.state.setdefault("flags", {})
+        memory = state.setdefault("memory", {})
+        self.state_flags: Dict[str, Any] = memory.setdefault("state_flags", {})
+        self.trait_scores: Dict[str, float] = memory.setdefault("trait_scores", {})
 
+    # ----- Flag management -------------------------------------------------
     def set_flag(self, name: str, value: Any = True) -> None:
-        """Set ``name`` to ``value`` in the flag dictionary."""
-        self.state["flags"][name] = value
+        """Set ``name`` to ``value`` in the state flag dictionary."""
+        self.state_flags[name] = value
 
     def get_flag(self, name: str, default: Any = None) -> Any:
         """Retrieve flag ``name`` or return ``default`` if unset."""
-        return self.state["flags"].get(name, default)
+        return self.state_flags.get(name, default)
 
     def check_flag(self, name: str, value: Any = True) -> bool:
-        """Return ``True`` if ``name`` equals ``value``."""
+        """Return ``True`` if flag ``name`` equals ``value``."""
         return self.get_flag(name) == value
+
+    # ----- Trait score management -----------------------------------------
+    def add_trait(self, trait: str, weight: float) -> None:
+        """Accumulate ``weight`` for ``trait`` in trait scores."""
+        if weight > 0:
+            self.trait_scores[trait] = self.trait_scores.get(trait, 0.0) + weight

--- a/tools/test_harness.py
+++ b/tools/test_harness.py
@@ -13,7 +13,8 @@ from typing import Any, Dict, List, Tuple
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from engine import (
-    default_state, load_scenarios, apply_choice_effects, 
+    default_state, load_scenarios, apply_choice_effects,
+    StateManager,
     show_final_reflection, Telemetry
 )
 from modules.reveal import load_reveals, pick_reveal
@@ -126,9 +127,10 @@ class TestHarness:
                 results["decisions_made"].append(decision_record)
                 
                 # Apply choice effects
-                traits_before = dict(state["player"]["traits"])
-                apply_choice_effects(state, chosen_choice, telemetry, debug_mode=True)
-                traits_after = dict(state["player"]["traits"])
+                state_mgr = StateManager(state)
+                traits_before = dict(state["memory"]["trait_scores"])
+                apply_choice_effects(state, chosen_choice, state_mgr, telemetry, debug_mode=True)
+                traits_after = dict(state["memory"]["trait_scores"])
                 
                 # Record trait changes
                 trait_changes = {}
@@ -157,13 +159,13 @@ class TestHarness:
                         print("No trait changes (decoy choice)")
             
             # Final analysis
-            results["final_traits"] = dict(state["player"]["traits"])
+            results["final_traits"] = dict(state["memory"]["trait_scores"])
             
             # Get final reveal
             reveals_path = self.data_path / "payoffs" / "endgame_reveals.json"
             if reveals_path.exists():
                 reveal_data = load_reveals(reveals_path)
-                reveal = pick_reveal(state["player"]["traits"], reveal_data)
+                reveal = pick_reveal(state["memory"]["trait_scores"], reveal_data)
                 results["final_reveal"] = reveal["text"]
             else:
                 results["final_reveal"] = "No reveal data available"


### PR DESCRIPTION
## Summary
- persist story flags and trait scores in new state manager memory
- insert act intros, interludes, and scene variations based on stored flags
- track mirror, beast, and storm interactions across acts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0e5e87c8832390959b4d719b136f