### PR TITLE
feat: add symbol trait mapping

### DIFF
--- a/data/scenarios/act1_mirrors.json
+++ b/data/scenarios/act1_mirrors.json
@@ -4,10 +4,11 @@
   "title": "Mirrors",
   "description": "Dreamlike, self-confrontational scenarios exploring personal reflection.",
   "scenes": [
-    {
-      "scene_id": "mirror_pool",
-      "type": "micro",
-      "text": "A still pool mirrors the sky; your reflection waits for a ripple.",
+      {
+        "scene_id": "mirror_pool",
+        "type": "micro",
+        "symbol": "mirror",
+        "text": "A still pool mirrors the sky; your reflection waits for a ripple.",
       "choices": [
         {
           "choice_id": "touch_surface",
@@ -102,10 +103,11 @@
         }
       ]
     },
-    {
-      "scene_id": "confessing_mirror",
-      "type": "micro",
-      "text": "A mirror asks what flaw you hide.",
+      {
+        "scene_id": "confessing_mirror",
+        "type": "micro",
+        "symbol": "mirror",
+        "text": "A mirror asks what flaw you hide.",
       "choices": [
         {
           "choice_id": "admit_fault",

--- a/data/scenarios/act2_beasts.json
+++ b/data/scenarios/act2_beasts.json
@@ -7,6 +7,7 @@
     {
       "scene_id": "wounded_boar",
       "type": "micro",
+      "symbol": "beast",
       "text": "A boar stumbles before you, its flank pierced by spears.",
       "choices": [
           {
@@ -44,6 +45,7 @@
     {
       "scene_id": "caged_lion",
       "type": "micro",
+      "symbol": "beast",
       "text": "Iron bars groan as a lion hurls itself against them.",
       "choices": [
           {
@@ -77,6 +79,7 @@
     {
       "scene_id": "trembling_hare",
       "type": "micro",
+      "symbol": "beast",
       "text": "A trembling hare hides beneath a broken statue.",
       "choices": [
         {
@@ -100,6 +103,7 @@
     {
       "scene_id": "shadow_wolves",
       "type": "micro",
+      "symbol": "beast",
       "text": "Spectral wolves circle, their eyes reflecting yours.",
       "choices": [
         {
@@ -133,6 +137,7 @@
     {
       "scene_id": "coiled_serpent",
       "type": "micro",
+      "symbol": "beast",
       "text": "A serpent coils around an abandoned helm, tongue tasting the air.",
       "choices": [
         {
@@ -156,6 +161,7 @@
     {
       "scene_id": "rampaging_bull",
       "type": "micro",
+      "symbol": "beast",
       "text": "A bull of smoke charges blindly through crumbling ruins.",
       "choices": [
         {
@@ -179,6 +185,7 @@
     {
       "scene_id": "jealous_raven",
       "type": "micro",
+      "symbol": "beast",
       "text": "A raven guards a glittering trove stolen from travelers.",
       "choices": [
         {
@@ -202,6 +209,7 @@
     {
       "scene_id": "sleeping_dragon",
       "type": "micro",
+      "symbol": "beast",
       "text": "A dragon slumbers atop cold embers, smoke curling from its nostrils.",
       "choices": [
         {
@@ -225,6 +233,7 @@
     {
       "scene_id": "verdict_pit",
       "type": "mid",
+      "symbol": "beast",
       "text": "A captured chimera kneels in a pit as the crowd roars for judgment.",
       "choices": [
         {
@@ -256,6 +265,7 @@
     {
       "scene_id": "feeding_pit",
       "type": "mid",
+      "symbol": "beast",
       "text": "Starving beasts claw at one another for scraps thrown into a pit.",
       "choices": [
         {
@@ -287,6 +297,7 @@
     {
       "scene_id": "blood_vow",
       "type": "micro",
+      "symbol": "beast",
       "text": "A beast extends a claw, demanding a blood oath for safe passage.",
       "choices": [
         {
@@ -310,6 +321,7 @@
     {
       "scene_id": "mirror_chimera",
       "type": "pocket",
+      "symbol": "beast",
       "text": "A chimera with mirrored scales reflects your every motion.",
       "choices": [
         {

--- a/data/scenarios/act3_whispers.json
+++ b/data/scenarios/act3_whispers.json
@@ -96,10 +96,11 @@
         }
       ]
     },
-    {
-      "scene_id": "storm_door",
-      "type": "micro",
-      "text": "A door pulses with light and shadow as a storm rages behind it.",
+      {
+        "scene_id": "storm_door",
+        "type": "micro",
+        "symbol": "storm",
+        "text": "A door pulses with light and shadow as a storm rages behind it.",
       "choices": [
         {
           "choice_id": "open_anyway",

--- a/src/engine.py
+++ b/src/engine.py
@@ -16,6 +16,7 @@ from modules.telemetry import Telemetry
 from modules.reveal import load_reveals, pick_reveal
 from modules.state_manager import StateManager
 from modules.scoring import normalize_scores, top_archetype
+from modules.symbols import describe as describe_symbol
 
 
 def default_state() -> Dict[str, Any]:
@@ -201,9 +202,19 @@ def apply_state_variations(scene: Dict[str, Any], act_num: int, state_mgr: State
             scene["text"] += " The mirror's calm steadies your resolve."
     if act_num >= 3:
         if beast == "spared":
-            scene["text"] += " A grateful beast's shadow follows." 
+            scene["text"] += " A grateful beast's shadow follows."
         elif beast == "slain":
             scene["text"] += " The cry of a slain beast echoes at your back."
+
+
+def apply_symbol_rules(scene: Dict[str, Any], state_mgr: StateManager) -> None:
+    """Modify symbol scenes based on dominant related traits."""
+    symbol = scene.get("symbol")
+    if not symbol:
+        return
+    desc = describe_symbol(symbol, state_mgr.trait_scores)
+    if desc:
+        scene["text"] += f" {desc}"
 
 
 def act_intro(act_num: int, state_mgr: StateManager) -> None:
@@ -285,6 +296,7 @@ def run_act(act_num: int, scenes: List[Dict[str, Any]], state: Dict[str, Any], s
 
         apply_scene_callbacks(scene, state_mgr)
         apply_state_variations(scene, act_num, state_mgr)
+        apply_symbol_rules(scene, state_mgr)
 
         if show_hud_flag:
             show_hud(state, debug_mode)

--- a/src/modules/symbols.py
+++ b/src/modules/symbols.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Central symbol descriptions and trait mappings."""
+from typing import Dict, Tuple
+
+# Mapping of symbols to their associated traits (dominant vs alternative)
+SYMBOL_TRAIT_MAP: Dict[str, Tuple[str, str]] = {
+    "mirror": ("self_reflection", "avoidance"),
+    "beast": ("aggression", "restraint"),
+    "storm": ("unresolved_conflict", "decisiveness"),
+}
+
+# Text variations keyed by symbol and dominant trait.
+SYMBOL_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
+    "mirror": {
+        "self_reflection": "The mirror invites a hard look within.",
+        "avoidance": "The mirror's surface clouds as you shy from it.",
+    },
+    "beast": {
+        "aggression": "The beast's snarl deepens, daring confrontation.",
+        "restraint": "The beast watches you, muscles tight but held in check.",
+    },
+    "storm": {
+        "unresolved_conflict": "The storm churns with unresolved tensions.",
+        "decisiveness": "The storm parts, revealing a brief path forward.",
+    },
+}
+
+
+def describe(symbol: str, traits: Dict[str, float]) -> str:
+    """Return a symbol description based on dominant related trait scores."""
+    trait_pair = SYMBOL_TRAIT_MAP.get(symbol)
+    if not trait_pair:
+        return ""
+    primary, secondary = trait_pair
+    primary_score = traits.get(primary, 0.0)
+    secondary_score = traits.get(secondary, 0.0)
+    key = primary if primary_score >= secondary_score else secondary
+    return SYMBOL_DESCRIPTIONS.get(symbol, {}).get(key, "")


### PR DESCRIPTION
## Summary
- map mirror, beast and storm imagery to associated traits
- vary symbol scene text using dominant trait scores
- tag scenario scenes with their symbol for later recall

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d10d5e26083239e46d2960524ae76