### PR TITLE
docs: update project status with all sprints

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -17,10 +17,10 @@ Project Janus is a retro-inspired text RPG where player choices both guide the s
 - `python -m pytest` → **17 passed**, 2 warnings (deprecated `datetime.utcnow`).
 
 ## Recent Activity
-- `568cab1` – fix: update version to v2.1-alpha
+- `0807e5d` – merge: assess project state and document findings
 
 ## Sprint Progress
-Sixteen sprints delivered:
+Twenty-two sprints delivered:
 1. Trait glossary and tagging API.
 2. Act 1 "Mirrors" scenarios.
 3. Act 2 "Beasts" scenarios.
@@ -36,7 +36,13 @@ Sixteen sprints delivered:
 13. Testing dashboard and control panel.
 14. Data ingestion & analytics baseline.
 15. Calibrator & optimization utilities.
-16. Dashboard "Personality Mixer" with live slider readouts.
+ 16. Dashboard "Personality Mixer" with live slider readouts.
+17. Persistent state & narrative callbacks.
+18. Expanded choice architecture with multi-option scenes.
+19. Psychological payoff system upgrade for trait-based archetypes.
+20. Story spine & continuity pass linking acts through stateful interludes.
+21. Internal mythos & meaning mapping via symbol–trait links.
+22. Hero’s Chronicle endgame with personalized summaries.
 
 ## Next Steps
 - Gather feedback from alpha/beta testers.

--- a/reports/README.md
+++ b/reports/README.md
@@ -4,5 +4,5 @@ Progress and analytics reports for Project Janus.
 
 ## Files
 
-- `sprint_report.md` - Summary of accomplishments across sixteen development sprints.
+- `sprint_report.md` - Summary of accomplishments across twenty-two development sprints.
 - `baseline_metrics.md` - Initial calibration and analytics benchmarks.

--- a/reports/sprint_report.md
+++ b/reports/sprint_report.md
@@ -1,7 +1,7 @@
 # Project Janus – Sprint Report
 
 ## Overview
-This document summarizes the work completed across sixteen development sprints and the current state of the Project Janus repository.
+This document summarizes the work completed across twenty-two development sprints and the current state of the Project Janus repository.
 
 ## Sprint Accomplishments
 1. **Sprint 1 – Trait glossary and tagging API.** Introduced psychological weighting for quest choices, enabling traits to be tracked throughout gameplay.
@@ -20,6 +20,12 @@ This document summarizes the work completed across sixteen development sprints a
 14. **Sprint 14 – Data ingestion & analytics baseline.** Added canonical trait mapping, run ingestion scripts, and baseline calibration metrics.
 15. **Sprint 15 – Calibrator & optimization.** Implemented bounded calibration utilities, optimizer, and configuration snapshot output.
 16. **Sprint 16 – Dashboard "Personality Mixer."** Integrated a calibration tab with live slider readouts for policy multipliers and master controls.
+17. **Sprint 17 – Persistent state & narrative callbacks.** Added a state manager and cross-scene hooks so earlier choices influence later scenes.
+18. **Sprint 18 – Expanded choice architecture.** Enabled multi-option scenes with trait tagging for richer decisions.
+19. **Sprint 19 – Psychological payoff system upgrade.** Introduced trait-scoring and archetype-based endings.
+20. **Sprint 20 – Story spine & continuity pass.** Wove act intros and interludes referencing player state for cohesive progression.
+21. **Sprint 21 – Internal mythos & meaning mapping.** Linked recurring symbols to traits and adjusted scenes based on them.
+22. **Sprint 22 – Hero’s Chronicle & psychological payoff.** Generated personalised endgame summaries and symbolic epilogues.
 
 ## Repository Status
 - Source code and data are organized under clearly defined directories (`src/`, `data/`, `archive/versions/`, etc.).


### PR DESCRIPTION
## Summary
- List all 22 development sprints in `PROJECT_STATUS.md`
- Extend sprint report and README to reflect sprints 17–22

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689de288d20c832383133f5a0982b6ed