### PR TITLE
feat: polish decision UI and ambience

### DIFF
--- a/pilot_humility_hubris/frontend/index.html
+++ b/pilot_humility_hubris/frontend/index.html
@@ -24,7 +24,7 @@
       color: hsl(var(--text));
       background: radial-gradient(1200px 800px at 20% 10%, hsla(var(--bg-hue), 50%, 16%, 0.6), transparent),
                   linear-gradient(145deg, hsla(var(--bg-hue), 40%, 10%, 1), hsla(calc(var(--bg-hue) + 40), 45%, 7%, 1));
-      transition: background 600ms ease;
+      transition: background 1200ms ease, filter 1200ms ease;
       overflow: hidden;
     }
 
@@ -89,24 +89,42 @@
       position: absolute; width: 160px; height: 44px; display: grid; place-items: center; padding: 6px 10px;
       background: hsla(var(--bg-hue), 20%, 70%, 0.06); border: 1px solid rgba(255,255,255,0.18); border-radius: 12px; cursor: pointer;
       transition: transform 200ms ease, background 200ms ease, box-shadow 200ms ease, opacity 200ms ease;
+      opacity: 0; transform: scale(0.8); animation: choiceIn 400ms ease forwards;
     }
-    .orbit .glyph:hover { background: hsla(var(--bg-hue), 40%, 60%, 0.12); box-shadow: 0 6px 24px rgba(0,0,0,0.35); }
+    .orbit .glyph:hover {
+      background: hsla(var(--bg-hue), 40%, 60%, 0.12);
+      box-shadow: 0 0 12px hsla(var(--bg-hue),70%,70%,0.45);
+      animation: orbitHover 1.6s ease-in-out infinite;
+      transform: scale(1.05);
+    }
+    .orbit .glyph.selected { box-shadow: 0 0 20px hsla(var(--bg-hue),80%,60%,0.65); }
+    @keyframes orbitHover {
+      0%,100% { box-shadow: 0 0 12px hsla(var(--bg-hue),70%,70%,0.0); }
+      50% { box-shadow: 0 0 18px hsla(var(--bg-hue),70%,70%,0.6); }
+    }
+    @keyframes choiceIn {
+      from { opacity: 0; transform: scale(0.6); }
+      to { opacity: 1; transform: scale(1); }
+    }
 
     /* Lens cards */
     .lens-wrap { position: relative; width: 100%; height: 100%; display: grid; grid-template-columns: 1fr 1fr; gap: 16px; align-items: center; }
     .lens-card {
       position: relative; padding: 18px; height: 160px; display: grid; place-items: center; text-align: center;
       background: linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0.03)); border: 1px solid rgba(255,255,255,0.18); border-radius: 14px;
-      filter: blur(6px) saturate(0.9); overflow: hidden; cursor: none;
+      filter: blur(6px) saturate(0.8) brightness(0.9); overflow: hidden; cursor: none;
       -webkit-mask-image: radial-gradient(120px 120px at var(--mx,50%) var(--my,50%), rgba(0,0,0,1) 0%, rgba(0,0,0,0.0) 60%);
       mask-image: radial-gradient(120px 120px at var(--mx,50%) var(--my,50%), rgba(0,0,0,1) 0%, rgba(0,0,0,0.0) 60%);
       transition: filter 200ms ease;
+      opacity: 0; transform: scale(0.96); animation: choiceIn 400ms ease forwards;
     }
+    .lens-card.focus { filter: blur(0) saturate(1.2) brightness(1.1); }
     .lens-card .hint { position: absolute; bottom: 8px; right: 10px; font-size: 11px; color: hsl(var(--muted)); opacity: 0.8; }
 
     /* Echo ripple */
-    .ripple { position: fixed; width: 10px; height: 10px; border-radius: 50%; pointer-events: none; background: radial-gradient(circle, hsla(var(--bg-hue),70%,65%,0.55), hsla(var(--bg-hue),70%,65%,0.0)); animation: ripple 900ms ease-out forwards; }
-    @keyframes ripple { from { transform: scale(0.6); opacity: 0.9; } to { transform: scale(40); opacity: 0; } }
+    .ripple { position: fixed; width: 10px; height: 10px; border-radius: 50%; pointer-events: none; background: radial-gradient(circle, hsla(var(--bg-hue),70%,65%,0.45), hsla(var(--bg-hue),70%,65%,0.0)); animation: ripple 900ms ease-out forwards; }
+    .ripple.faint { opacity: 0.35; animation: ripple 1200ms ease-out forwards; }
+    @keyframes ripple { from { transform: scale(0.6); opacity: 0.8; } to { transform: scale(40); opacity: 0; } }
 
     /* Scene transition */
     .dissolve { animation: dissolve 420ms ease both; }
@@ -128,6 +146,13 @@
       .orbit { width: 320px; height: 320px; }
       .lens-wrap { grid-template-columns: 1fr; }
       #constellation { width: 200px; height: 120px; }
+    }
+    @media (max-width: 600px) {
+      .hud { height: 56px; }
+      .panel { inset: 70px 12px 12px; }
+      .orbit { width: 260px; height: 260px; }
+      .lens-card { height: 130px; }
+      .title { font-size: 18px; }
     }
   </style>
 </head>
@@ -348,7 +373,11 @@
       node.textContent = opt.label;
       node.style.left = x + 'px';
       node.style.top = y + 'px';
-      node.addEventListener('click', (ev)=> handleChoice(opt, {x: ev.clientX, y: ev.clientY}));
+      node.style.animationDelay = (i * 80) + 'ms';
+      node.addEventListener('click', (ev)=>{
+        node.classList.add('selected');
+        handleChoice(opt, {x: ev.clientX, y: ev.clientY});
+      });
       wrap.appendChild(node);
     });
     decision.appendChild(wrap);
@@ -360,16 +389,19 @@
   function renderLens(options){
     const wrap = document.createElement('div');
     wrap.className = 'lens-wrap';
-    options.forEach((opt)=>{
+    options.forEach((opt, i)=>{
       const card = document.createElement('div');
       card.className = 'lens-card';
       card.innerHTML = `<div>${opt.label}</div><div class="hint">Focus the lens, then click</div>`;
+      card.style.animationDelay = (i * 80) + 'ms';
       card.addEventListener('mousemove', (e)=>{
         const rect = card.getBoundingClientRect();
         const x = e.clientX - rect.left, y = e.clientY - rect.top;
         card.style.setProperty('--mx', x + 'px');
         card.style.setProperty('--my', y + 'px');
       });
+      card.addEventListener('mouseenter', ()=> card.classList.add('focus'));
+      card.addEventListener('mouseleave', ()=> card.classList.remove('focus'));
       card.addEventListener('click', (ev)=> handleChoice(opt, {x: ev.clientX, y: ev.clientY}));
       wrap.appendChild(card);
     });
@@ -514,12 +546,15 @@
   function clamp(v, a, b){ return Math.max(a, Math.min(b, v)); }
 
   function echoRipple(x, y){
-    const r = document.createElement('span');
-    r.className = 'ripple';
-    r.style.left = (x - 5) + 'px';
-    r.style.top = (y - 5) + 'px';
-    document.body.appendChild(r);
-    r.addEventListener('animationend', ()=> r.remove());
+    ['','faint'].forEach((cls, i)=>{
+      const r = document.createElement('span');
+      r.className = 'ripple' + (cls ? ' ' + cls : '');
+      r.style.left = (x - 5) + 'px';
+      r.style.top = (y - 5) + 'px';
+      if(i) r.style.animationDelay = '120ms';
+      document.body.appendChild(r);
+      r.addEventListener('animationend', ()=> r.remove());
+    });
   }
 
   // -----------------------------
@@ -536,6 +571,8 @@
       y: Math.random()*h,
       r: Math.random()*1.7 + 0.3,
       b: Math.random()*0.4 + 0.2,
+      vx: (Math.random()-0.5)*0.05,
+      vy: (Math.random()-0.5)*0.05,
     }));
   }
   window.addEventListener('resize', initStars);
@@ -545,17 +582,35 @@
     const h = canvas.height = canvas.clientHeight;
     ctx.clearRect(0,0,w,h);
 
+    const hue = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--bg-hue')) || 0;
+
     // cluster centers move subtly with trait (–1..1) → shift focus left/right
     const cx = w*(0.35 + 0.3*((trait+1)/2));
     const cy = h*0.55;
 
     for (const s of stars){
+      s.x = (s.x + s.vx + w) % w;
+      s.y = (s.y + s.vy + h) % h;
+      s.b = clamp(s.b + (Math.random()-0.5)*0.01, 0.2, 0.6);
       const dx = s.x - cx, dy = s.y - cy; const d = Math.sqrt(dx*dx + dy*dy) + 1;
       const glow = 1 / (d*0.04); // nearer to cluster is brighter
       const alpha = clamp(s.b + glow*0.9, 0, 1);
       ctx.beginPath(); ctx.arc(s.x, s.y, s.r, 0, Math.PI*2);
-      ctx.fillStyle = `rgba(255,255,255,${alpha})`;
+      ctx.fillStyle = `hsla(${hue},50%,80%,${alpha})`;
       ctx.fill();
+    }
+
+    for(let i=0;i<stars.length;i++){
+      for(let j=i+1;j<stars.length;j++){
+        const a = stars[i], b = stars[j];
+        const dx = a.x-b.x, dy = a.y-b.y; const d = Math.sqrt(dx*dx+dy*dy);
+        if(d < 50){
+          const alpha = 0.1 * (1 - d/50);
+          ctx.strokeStyle = `hsla(${hue},60%,70%,${alpha})`;
+          ctx.lineWidth = 0.5;
+          ctx.beginPath(); ctx.moveTo(a.x,a.y); ctx.lineTo(b.x,b.y); ctx.stroke();
+        }
+      }
     }
     requestAnimationFrame(tick);
   }


### PR DESCRIPTION
## Summary
- add entry animations and hover/selection effects to Orbit Selector glyphs
- enhance Cognitive Lens focus transitions and responsiveness
- refine background ambience with drifting stars, connecting lines, and layered ripple feedback

## Testing
- `PYTHONPATH=. pytest pilot_humility_hubris/tests/test_hh_scoring.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e063886e883238daa19a0a57bd104