### PR TITLE
feat: add multi-trait system with sigils and whisper panel

### DIFF
--- a/pilot_humility_hubris/frontend/index.html
+++ b/pilot_humility_hubris/frontend/index.html
@@ -22,8 +22,8 @@
     body {
       margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
       color: hsl(var(--text));
-      background: radial-gradient(1200px 800px at 20% 10%, hsla(var(--bg-hue), 50%, 16%, 0.6), transparent),
-                  linear-gradient(145deg, hsla(var(--bg-hue), 40%, 10%, 1), hsla(calc(var(--bg-hue) + 40), 45%, 7%, 1));
+      background: radial-gradient(1200px 800px at 20% 10%, hsla(var(--bg-hue), var(--bg-sat), calc(var(--bg-light) + 8%), 0.6), transparent),
+                  linear-gradient(145deg, hsla(var(--bg-hue), calc(var(--bg-sat) - 10%), var(--bg-light), 1), hsla(calc(var(--bg-hue) + 40), var(--bg-sat), calc(var(--bg-light) - 3%), 1));
       transition: background 1200ms ease, filter 1200ms ease;
       overflow: hidden;
     }
@@ -140,6 +140,17 @@
     /* Helper badges */
     .badge { display: inline-block; padding: 3px 8px; border-radius: 999px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.16); font-size: 11px; color: hsl(var(--muted)); }
 
+    /* Sigil repository */
+    #sigils { display:flex; gap:6px; flex-wrap:wrap; margin-top:6px; }
+    .sigil { width:20px; height:20px; opacity:0.25; transition:opacity 300ms ease, transform 300ms ease; }
+    .sigil.active { opacity:0.85; transform:scale(1.2); }
+    .sigil svg { width:100%; height:100%; stroke: hsl(var(--text)); }
+
+    /* Whisper panel */
+    .whisper-wrap { display:grid; gap:12px; text-align:center; }
+    .whisper-text { font-style:italic; opacity:0.85; }
+    .whisper-actions { display:flex; gap:10px; justify-content:center; }
+
     /* Mobile */
     @media (max-width: 920px) {
       .panel { grid-template-columns: 1fr; inset: 76px 14px 14px; }
@@ -167,6 +178,7 @@
           <select id="mode">
             <option value="orbit">Orbit Selector</option>
             <option value="lens">Cognitive Lens</option>
+            <option value="whisper">Whisper Panel</option>
           </select>
         </span>
         <button id="restart">Restart</button>
@@ -175,7 +187,7 @@
 
     <div id="start">
       <div class="card start-card">
-        <div class="badge">Alpha · Single‑Trait Continuum: Humility ↔ Hubris</div>
+        <div class="badge">Alpha · Multi‑Trait Prototype</div>
         <h1 class="start-title">Enter the Labyrinth</h1>
         <p class="start-blurb">Make a series of small choices. The world will shift around you. Nothing is scored, but something is revealed.<br/>
         <em>Controls:</em> Click choices · Press <strong>1/2</strong> to choose · Switch decision UI anytime.</p>
@@ -206,12 +218,16 @@
           </div>
           <span class="badge">Hubris</span>
         </div>
-        <div style="margin-top:16px;">
-          <h4 class="subtitle" style="margin:0 0 6px 0;">Constellation Bloom</h4>
-          <div class="subtitle">Faint lights gather where patterns repeat.</div>
-        </div>
-      </section>
-    </div>
+          <div style="margin-top:16px;">
+            <h4 class="subtitle" style="margin:0 0 6px 0;">Constellation Bloom</h4>
+            <div class="subtitle">Faint lights gather where patterns repeat.</div>
+          </div>
+          <div style="margin-top:16px;">
+            <h4 class="subtitle" style="margin:0 0 6px 0;">Glyph Repository</h4>
+            <div id="sigils"></div>
+          </div>
+        </section>
+      </div>
 
     <div id="reflection" style="display:none;" class="panel">
       <section class="card reflect-grid">
@@ -243,8 +259,8 @@
       subtitle: 'A still pool mirrors the sky; your reflection waits for a ripple.',
       text: 'The surface holds your outline with too much patience.',
       options: [
-        { id:'disturb', label: 'Disturb the surface and watch your face fracture.', delta:+0.6, whisper: 'You broke the stillness first.' },
-        { id:'wait', label: 'Stand motionless until the water calms itself.', delta:-0.6, whisper: 'You let the world settle before you moved.' }
+        { id:'disturb', label: 'Disturb the surface and watch your face fracture.', delta:{ Hubris:+0.6, Impulsivity:+0.2 }, whisper: 'You broke the stillness first.' },
+        { id:'wait', label: 'Stand motionless until the water calms itself.', delta:{ Hubris:-0.6, Rigidity:+0.2 }, whisper: 'You let the world settle before you moved.' }
       ]
     },
     {
@@ -252,8 +268,8 @@
       subtitle: 'Someone identical to you presents a thesis claiming your life’s work.',
       text: 'Their footnotes are perfect. Their voice is yours.',
       options: [
-        { id:'dissect', label: 'Publicly dissect their argument until they falter.', delta:+0.5, whisper: 'You answered threat with edge.' },
-        { id:'applaud', label: 'Applaud politely and leave the hall.', delta:-0.4, whisper: 'You passed through without contest.' }
+        { id:'dissect', label: 'Publicly dissect their argument until they falter.', delta:{ Hubris:+0.5, Wrath:+0.2 }, whisper: 'You answered threat with edge.' },
+        { id:'applaud', label: 'Applaud politely and leave the hall.', delta:{ Hubris:-0.4, Apathy:+0.2 }, whisper: 'You passed through without contest.' }
       ]
     },
     {
@@ -261,8 +277,8 @@
       subtitle: 'Empty frames reflect only echoes.',
       text: 'A room that remembers sound better than faces.',
       options: [
-        { id:'hum', label: 'Hum a fragment of song and listen for an answer.', delta:-0.35, whisper: 'You invited the room to speak first.' },
-        { id:'silence', label: 'Close the parlor door and keep the silence.', delta:+0.35, whisper: 'You prized control over reply.' }
+        { id:'hum', label: 'Hum a fragment of song and listen for an answer.', delta:{ Hubris:-0.35, Moodiness:+0.2 }, whisper: 'You invited the room to speak first.' },
+        { id:'silence', label: 'Close the parlor door and keep the silence.', delta:{ Hubris:+0.35, Control:+0.2 }, whisper: 'You prized control over reply.' }
       ]
     },
     {
@@ -270,8 +286,8 @@
       subtitle: 'A hidden pond whispers a riddle only you can hear.',
       text: 'Every answer is a door; most are locked from the other side.',
       options: [
-        { id:'clever', label: 'Answer with a clever twist that feels like a lie.', delta:+0.5, whisper: 'You shaped truth into a better weapon.' },
-        { id:'stones', label: 'Skip stones until the question dissolves.', delta:-0.5, whisper: 'You refused the duel of tongues.' }
+        { id:'clever', label: 'Answer with a clever twist that feels like a lie.', delta:{ Hubris:+0.5, Deception:+0.3 }, whisper: 'You shaped truth into a better weapon.' },
+        { id:'stones', label: 'Skip stones until the question dissolves.', delta:{ Hubris:-0.5, Apathy:+0.3 }, whisper: 'You refused the duel of tongues.' }
       ]
     },
     {
@@ -279,14 +295,43 @@
       subtitle: 'Two doors lean toward you like choices already chosen.',
       text: 'One is licked by flame. One is draped in shadow. Both are unlocked.',
       options: [
-        { id:'flame', label: 'Step through the flame‑licked archway.', delta:+0.6, whisper: 'You walked where light demands tribute.' },
-        { id:'shadow', label: 'Pass by the shadow‑draped gate.', delta:-0.6, whisper: 'You chose the softness that hides its edge.' }
+        { id:'flame', label: 'Step through the flame‑licked archway.', delta:{ Hubris:+0.6, Wrath:+0.3 }, whisper: 'You walked where light demands tribute.' },
+        { id:'shadow', label: 'Pass by the shadow‑draped gate.', delta:{ Hubris:-0.6, Fear:+0.3 }, whisper: 'You chose the softness that hides its edge.' }
       ]
     }
   ];
-
-  // Trait state: single continuum (Humility ↔ Hubris). Positive => Hubris, Negative => Humility
-  let trait = 0; // -1..1 
+ 
+  // Trait state: multi-trait object from Hamartia Engine
+  const TRAIT_KEYS = ['Hubris','Avarice','Deception','Wrath','Impulsivity','Rigidity','Moodiness','Control','Fear','Apathy','Envy','Cynicism'];
+  const traits = Object.fromEntries(TRAIT_KEYS.map(t=>[t,0]));
+  const SIGILS = {
+    Hubris:'<svg viewBox="0 0 20 20"><path d="M10 2 L14 14 L6 14 Z" fill="currentColor"/></svg>',
+    Avarice:'<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="6" fill="none"/></svg>',
+    Deception:'<svg viewBox="0 0 20 20"><rect x="4" y="4" width="12" height="12" fill="none"/><path d="M4 4 L16 16" fill="none"/></svg>',
+    Wrath:'<svg viewBox="0 0 20 20"><path d="M10 2 L12 10 L10 18 L8 10 Z" fill="currentColor"/></svg>',
+    Impulsivity:'<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="3" fill="currentColor"/><path d="M10 0 V6" fill="none"/><path d="M10 14 V20" fill="none"/></svg>',
+    Rigidity:'<svg viewBox="0 0 20 20"><path d="M4 4 H16 V16 H4 Z" fill="none"/></svg>',
+    Moodiness:'<svg viewBox="0 0 20 20"><path d="M2 10 Q10 2 18 10 Q10 18 2 10Z" fill="none"/></svg>',
+    Control:'<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="8" fill="none"/><circle cx="10" cy="10" r="3" fill="currentColor"/></svg>',
+    Fear:'<svg viewBox="0 0 20 20"><circle cx="10" cy="10" r="8" fill="none"/><circle cx="10" cy="13" r="2" fill="currentColor"/></svg>',
+    Apathy:'<svg viewBox="0 0 20 20"><path d="M4 10 H16" fill="none"/></svg>',
+    Envy:'<svg viewBox="0 0 20 20"><path d="M10 4 L14 10 L10 16 L6 10 Z" fill="none"/></svg>',
+    Cynicism:'<svg viewBox="0 0 20 20"><path d="M3 7 H17 L13 13 H7 Z" fill="none"/></svg>'
+  };
+  const TRAIT_COLORS = {
+    Hubris:[35,80,50],
+    Avarice:[50,85,45],
+    Deception:[330,60,50],
+    Wrath:[0,75,45],
+    Impulsivity:[25,90,50],
+    Rigidity:[200,30,45],
+    Moodiness:[260,35,40],
+    Control:[180,35,45],
+    Fear:[210,35,35],
+    Apathy:[150,20,60],
+    Envy:[120,70,40],
+    Cynicism:[210,20,50]
+  };
   const journal = []; // poetic echo lines
   const path = [];    // record of choices
   let sceneIndex = 0;
@@ -303,6 +348,7 @@
   const sceneText = document.getElementById('sceneText');
   const decision = document.getElementById('decision');
   const traitBar = document.getElementById('traitBar');
+  const sigilRepo = document.getElementById('sigils');
   const modeSelect = document.getElementById('mode');
   const restart = document.getElementById('restart');
   const portrait = document.getElementById('portrait');
@@ -330,7 +376,9 @@
     start.style.display = 'none';
     reflection.style.display = 'none';
     game.style.display = '';
-    trait = 0; sceneIndex = 0; journal.length = 0; path.length = 0;
+    TRAIT_KEYS.forEach(k=> traits[k] = 0);
+    sigilRepo.innerHTML = '';
+    sceneIndex = 0; journal.length = 0; path.length = 0;
     renderScene();
     updateAtmosphere();
   }
@@ -353,7 +401,9 @@
     setTimeout(()=> decision.classList.remove('dissolve'), 460);
 
     const mode = modeSelect.value;
-    if (mode === 'orbit') renderOrbit(s.options); else renderLens(s.options);
+    if (mode === 'orbit') renderOrbit(s.options);
+    else if (mode === 'lens') renderLens(s.options);
+    else renderWhisper(s.options);
   }
 
   // -----------------------------
@@ -409,14 +459,42 @@
   }
 
   // -----------------------------
+  // Whisper Panel
+  // -----------------------------
+  function renderWhisper(options){
+    let idx = 0;
+    const wrap = document.createElement('div');
+    wrap.className = 'whisper-wrap';
+    const text = document.createElement('div');
+    text.className = 'whisper-text';
+    const actions = document.createElement('div');
+    actions.className = 'whisper-actions';
+    const accept = document.createElement('button');
+    accept.textContent = 'Accept';
+    const reject = document.createElement('button');
+    reject.textContent = 'Reject';
+    actions.appendChild(accept); actions.appendChild(reject);
+    wrap.appendChild(text);
+    wrap.appendChild(actions);
+    decision.appendChild(wrap);
+    function show(){ text.textContent = options[idx].label; }
+    accept.addEventListener('click', (ev)=> handleChoice(options[idx], {x: ev.clientX, y: ev.clientY}));
+    reject.addEventListener('click', ()=>{ idx = (idx+1)%options.length; show(); });
+    show();
+  }
+
+  // -----------------------------
   // Choice handling
   // -----------------------------
   function handleChoice(opt, point){
     // Echo ripple feedback
     echoRipple(point.x, point.y);
 
-    // Update trait & record
-    trait = clamp(trait + opt.delta, -1, 1);
+    // Update traits & record
+    for(const [k,v] of Object.entries(opt.delta || {})){
+      traits[k] = clamp((traits[k]||0) + v, -1, 1);
+      if(Math.abs(v) >= 0.4) showSigil(k);
+    }
     path.push({ scene: scenes[sceneIndex].id, choice: opt.id, delta: opt.delta });
     journal.push(`• ${opt.whisper}`);
 
@@ -432,19 +510,27 @@
   }
 
   function updateAtmosphere(){
-    // Map trait [-1..1] to hue (humility blue ~200, hubris amber ~35)
-    const hueHumility = 200, hueHubris = 35;
-    const t = (trait + 1)/2; // 0..1
-    const hue = Math.round(hueHumility * (1-t) + hueHubris * t);
-    document.documentElement.style.setProperty('--bg-hue', hue);
+    const entries = Object.entries(traits).sort((a,b)=>Math.abs(b[1]) - Math.abs(a[1]));
+    const top = entries.slice(0,3);
+    let total = 0, hue = 200, sat = 18, light = 8; // defaults
+    if(top.length){
+      hue = sat = light = 0;
+      top.forEach(([k,v])=>{
+        const weight = Math.abs(v);
+        const [h,s,l] = TRAIT_COLORS[k];
+        hue += h*weight; sat += s*weight; light += l*weight; total += weight;
+      });
+      hue /= total; sat /= total; light /= total;
+    }
+    document.documentElement.style.setProperty('--bg-hue', hue.toFixed(0));
+    document.documentElement.style.setProperty('--bg-sat', sat.toFixed(0)+'%');
+    document.documentElement.style.setProperty('--bg-light', light.toFixed(0)+'%');
 
-    // Accent for small UI tweaks if needed
     const accentHue = (hue + 20) % 360;
     document.documentElement.style.setProperty('--accent', `${accentHue}, 75%, 62%`);
 
-    // Trait bar (visual only, ambiguous)
-    const w = (0.5 + trait/2) * 100; // 0..100
-    traitBar.style.width = w + '%';
+    const hubris = traits.Hubris || 0;
+    traitBar.style.width = ((0.5 + hubris/2) * 100) + '%';
   }
 
   function showReflection(){
@@ -483,15 +569,16 @@
     const body = document.createElementNS(svgNS, 'path'); body.setAttribute('d','M110,180 Q150,150 190,180 L190,240 Q150,260 110,240 Z'); body.setAttribute('fill','rgba(255,255,255,0.12)'); body.setAttribute('stroke','rgba(255,255,255,0.25)');
     svg.appendChild(head); svg.appendChild(body);
 
-    // Trait-driven adornment
-    if (trait > 0.35) {
+    // Trait-driven adornment based on Hubris
+    const hubris = traits.Hubris || 0;
+    if (hubris > 0.35) {
       // Crown of light (Hubris‑lean)
       const crown = document.createElementNS(svgNS, 'path');
       crown.setAttribute('d','M118,78 L132,58 L150,80 L168,58 L182,78 Z');
       crown.setAttribute('fill','rgba(255,215,130,0.35)');
       crown.setAttribute('stroke','rgba(255,225,170,0.6)');
       svg.appendChild(crown);
-    } else if (trait < -0.35) {
+    } else if (hubris < -0.35) {
       // Halo (Humility‑lean)
       const halo = document.createElementNS(svgNS, 'ellipse');
       halo.setAttribute('cx','150'); halo.setAttribute('cy','72'); halo.setAttribute('rx','44'); halo.setAttribute('ry','10');
@@ -508,7 +595,7 @@
     portrait.appendChild(svg);
 
     // Reading text (neutral, non-judgmental)
-    const t = trait;
+    const t = hubris;
     let title, lines;
     if (t >= 0.55) {
       title = 'Mythic Persona: The Crowned Ember';
@@ -544,6 +631,19 @@
   }
 
   function clamp(v, a, b){ return Math.max(a, Math.min(b, v)); }
+
+  function showSigil(trait){
+    let node = sigilRepo.querySelector(`[data-trait="${trait}"]`);
+    if(!node){
+      node = document.createElement('div');
+      node.className = 'sigil';
+      node.dataset.trait = trait;
+      node.innerHTML = SIGILS[trait] || '';
+      sigilRepo.appendChild(node);
+    }
+    node.classList.add('active');
+    setTimeout(()=> node.classList.remove('active'), 800);
+  }
 
   function echoRipple(x, y){
     ['','faint'].forEach((cls, i)=>{
@@ -584,8 +684,9 @@
 
     const hue = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--bg-hue')) || 0;
 
-    // cluster centers move subtly with trait (–1..1) → shift focus left/right
-    const cx = w*(0.35 + 0.3*((trait+1)/2));
+    // cluster centers move subtly with hubris trait (–1..1) → shift focus left/right
+    const hubris = traits.Hubris || 0;
+    const cx = w*(0.35 + 0.3*((hubris+1)/2));
     const cy = h*0.55;
 
     for (const s of stars){


### PR DESCRIPTION
## Summary
- track all Hamartia Engine traits and record multi-trait deltas
- add glyph repository and trait sigil visuals with ambient blending
- introduce whisper panel decision interface alongside existing modes

## Testing
- `PYTHONPATH=$PWD pytest pilot_humility_hubris/tests/test_hh_scoring.py`


------
https://chatgpt.com/codex/tasks/task_e_689e07b3f1548323bd2f0c6e5e0d9d30