### PR TITLE
feat: add scene schema and validation preview

### DIFF
--- a/docs/scene-schema.md
+++ b/docs/scene-schema.md
@@ -1,0 +1,62 @@
+# Scene JSON Schema
+
+This document defines the structure for narrative scene files used in the
+`pilot_humility_hubris` prototype. Scenes are stored as individual JSON files
+in `pilot_humility_hubris/scenes/` and are loaded at runtime.
+
+## Top-level fields
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Unique identifier for the scene. |
+| `act` | string | Optional act or chapter label. |
+| `title` | string | Display title of the scene. |
+| `subtitle` | string | Optional subtitle shown beneath the title. |
+| `text` | string | Main body text presented to the player. |
+| `thread` | string | Optional thread or story line identifier used for callbacks. |
+| `set_flags` | array<string> | Flags set when this scene is entered. |
+| `require_flags` | array<string> | Flags required to enter the scene. |
+| `options` | array<object> | Available choices for the player. |
+
+## Option fields
+
+Each entry in `options` represents a player choice.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `id` | string | Unique identifier for this option within the scene. |
+| `label` | string | Text shown on the choice button. |
+| `whisper` | string | Short feedback line shown after selection. |
+| `delta` | object | Trait adjustments keyed by trait name. Values are numeric weights (e.g. `0.2`, `0.5`, `0.8`). |
+| `next` | string or null | Identifier of the next scene. `null` ends the run. |
+| `set_flags` | array<string> | Flags set when this option is taken. |
+| `require_flags` | array<string> | Flags required for the option to appear. |
+
+All fields other than `id`, `title`, `text`, and `options` are optional.
+
+## Replay metadata
+
+Preview scripts may record a `seed` and the sequence of option `id`s chosen.
+Replaying with the same seed and path will produce deterministic runs.
+
+## Example
+
+```json
+{
+  "id": "mirror_pool",
+  "act": "Act I · Mirrors",
+  "title": "Mirror Pool",
+  "subtitle": "A still pool mirrors the sky; your reflection waits for a ripple.",
+  "text": "The surface holds your outline with too much patience.",
+  "thread": "mirrors",
+  "options": [
+    {
+      "id": "disturb",
+      "label": "Disturb the surface and watch your face fracture.",
+      "whisper": "You broke the stillness first.",
+      "delta": {"Hubris": 0.6, "Impulsivity": 0.2},
+      "next": "twin_scholar"
+    }
+  ]
+}
+```

--- a/pilot_humility_hubris/frontend/data.js
+++ b/pilot_humility_hubris/frontend/data.js
@@ -206,3 +206,16 @@ export const CARD_GLYPHS = {
     'abandoned_stage': '<path d="M3 15 H17 L10 5 Z" fill="none" stroke="currentColor" stroke-width="2"/><path d="M5 12 Q10 8 15 12" stroke="currentColor" stroke-width="1.5" fill="none"/>', // Performance/Narrative
     'default': '<circle cx="10" cy="10" r="8" fill="none" stroke="currentColor" stroke-width="2"/><line x1="7" y1="10" x2="13" y2="10" stroke="currentColor" stroke-width="1.5"/>' // Generic placeholder
 };
+export const SCENE_SCHEMA_VERSION = 1;
+
+// Load scenes from external JSON files adhering to docs/scene-schema.md
+export async function loadScenes() {
+  const indexRes = await fetch('../scenes/index.json');
+  const index = await indexRes.json();
+  const scenes = [];
+  for (const file of index.scenes) {
+    const res = await fetch(`../scenes/${file}`);
+    scenes.push(await res.json());
+  }
+  return scenes;
+}

--- a/pilot_humility_hubris/scenes/index.json
+++ b/pilot_humility_hubris/scenes/index.json
@@ -1,0 +1,6 @@
+{
+  "scenes": [
+    "mirror_pool.json",
+    "twin_scholar.json"
+  ]
+}

--- a/pilot_humility_hubris/scenes/mirror_pool.json
+++ b/pilot_humility_hubris/scenes/mirror_pool.json
@@ -1,0 +1,26 @@
+{
+  "id": "mirror_pool",
+  "act": "Act I · Mirrors",
+  "title": "Mirror Pool",
+  "subtitle": "A still pool mirrors the sky; your reflection waits for a ripple.",
+  "text": "The surface holds your outline with too much patience.",
+  "thread": "mirrors",
+  "set_flags": ["saw_mirror_pool"],
+  "options": [
+    {
+      "id": "disturb",
+      "label": "Disturb the surface and watch your face fracture.",
+      "whisper": "You broke the stillness first.",
+      "delta": {"Hubris": 0.6, "Impulsivity": 0.2},
+      "next": "twin_scholar",
+      "set_flags": ["disturbed_pool"]
+    },
+    {
+      "id": "wait",
+      "label": "Stand motionless until the water calms itself.",
+      "whisper": "You let the world settle before you moved.",
+      "delta": {"Hubris": -0.6, "Rigidity": 0.2},
+      "next": "twin_scholar"
+    }
+  ]
+}

--- a/pilot_humility_hubris/scenes/twin_scholar.json
+++ b/pilot_humility_hubris/scenes/twin_scholar.json
@@ -1,0 +1,25 @@
+{
+  "id": "twin_scholar",
+  "act": "Act I · Mirrors",
+  "title": "Twin Scholar",
+  "subtitle": "Someone identical to you presents a thesis claiming your life’s work.",
+  "text": "Their footnotes are perfect. Their voice is yours.",
+  "thread": "mirrors",
+  "options": [
+    {
+      "id": "dissect",
+      "label": "Publicly dissect their argument until they falter.",
+      "whisper": "You answered threat with edge.",
+      "delta": {"Hubris": 0.5, "Wrath": 0.2},
+      "require_flags": ["disturbed_pool"],
+      "next": null
+    },
+    {
+      "id": "applaud",
+      "label": "Applaud politely and leave the hall.",
+      "whisper": "You passed through without contest.",
+      "delta": {"Hubris": -0.4, "Apathy": 0.2},
+      "next": null
+    }
+  ]
+}

--- a/tools/validate_scenes.py
+++ b/tools/validate_scenes.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Validate and preview scene JSON files for pilot_humility_hubris.
+
+This script loads all `.json` files from `pilot_humility_hubris/scenes/`,
+checks that they conform to `docs/scene-schema.md`, and optionally
+runs a deterministic preview of a single playthrough.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+SCENES_DIR = Path(__file__).resolve().parent.parent / "pilot_humility_hubris" / "scenes"
+
+REQUIRED_SCENE_FIELDS = {"id", "title", "text", "options"}
+REQUIRED_OPTION_FIELDS = {"id", "label", "delta"}
+
+
+def load_scenes() -> Tuple[Dict[str, dict], str]:
+    """Return scenes keyed by id and the default starting scene id."""
+    index_path = SCENES_DIR / "index.json"
+    with index_path.open() as f:
+        order = json.load(f)["scenes"]
+    scenes: Dict[str, dict] = {}
+    start_id: Optional[str] = None
+    for name in order:
+        path = SCENES_DIR / name
+        with path.open() as f:
+            data = json.load(f)
+        scenes[data["id"]] = data
+        if start_id is None:
+            start_id = data["id"]
+    if start_id is None:
+        raise ValueError("No scenes found")
+    return scenes, start_id
+
+
+def validate_scene(scene: dict) -> None:
+    missing = REQUIRED_SCENE_FIELDS - scene.keys()
+    if missing:
+        raise ValueError(f"Scene {scene.get('id')} missing fields: {missing}")
+    if not isinstance(scene["options"], list) or not scene["options"]:
+        raise ValueError(f"Scene {scene['id']} must contain options")
+    for opt in scene["options"]:
+        missing_opt = REQUIRED_OPTION_FIELDS - opt.keys()
+        if missing_opt:
+            raise ValueError(
+                f"Option {opt.get('id')} in scene {scene['id']} missing fields: {missing_opt}"
+            )
+        if not isinstance(opt["delta"], dict):
+            raise ValueError(
+                f"Option {opt['id']} in scene {scene['id']} has non-dict delta"
+            )
+
+
+def validate_all(scenes: Dict[str, dict]) -> None:
+    for scene in scenes.values():
+        validate_scene(scene)
+    print(f"Validated {len(scenes)} scene(s).")
+
+
+def preview(
+    scenes: Dict[str, dict],
+    seed: Optional[int] = None,
+    start: Optional[str] = None,
+    path: Optional[List[str]] = None,
+) -> List[str]:
+    rng = random.Random(seed)
+    current = start or next(iter(scenes))
+    taken: List[str] = []
+    while current:
+        scene = scenes[current]
+        options = scene["options"]
+        if path:
+            choice_id = path.pop(0)
+            choice = next((o for o in options if o["id"] == choice_id), None)
+            if choice is None:
+                raise ValueError(f"Choice {choice_id} not found in scene {current}")
+        else:
+            choice = rng.choice(options)
+        taken.append(choice["id"])
+        current = choice.get("next")
+    return taken
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate and preview scenes")
+    parser.add_argument("--preview", action="store_true", help="run a preview after validation")
+    parser.add_argument("--seed", type=int, default=None, help="random seed for preview")
+    parser.add_argument("--start", help="starting scene id")
+    parser.add_argument("--path", nargs="*", help="explicit option id path for replay")
+    args = parser.parse_args()
+
+    scenes, default_start = load_scenes()
+    validate_all(scenes)
+    if args.preview:
+        path = list(args.path) if args.path else None
+        start = args.start or default_start
+        taken = preview(scenes, seed=args.seed, start=start, path=path)
+        print("Preview path:", " -> ".join(taken))
+        if args.seed is not None:
+            print("Replay code:", json.dumps({"seed": args.seed, "path": taken}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document JSON structure for narrative scenes
- add validator and deterministic preview script
- load scenes from new JSON files via `loadScenes`

## Testing
- `python tools/validate_scenes.py --preview --seed 1`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e39006b40832389e8fcd457f50045