### PR TITLE
feat: clarify consequences and pacing

### DIFF
--- a/pilot_humility_hubris/frontend/index.html
+++ b/pilot_humility_hubris/frontend/index.html
@@ -14,10 +14,12 @@
 </head>
 <body>
   <div class="app" id="app">
+    <canvas id="constellation"></canvas>
     <div class="hud">
       <div class="brand">Project Janus · Prototype</div>
       <div class="controls">
-        <!-- REMOVED: <span class="pill">...</span> containing modeSelect -->
+        <label class="pill"><input type="checkbox" id="quick"> Quick</label>
+        <label class="pill"><input type="checkbox" id="ambience"> Ambience</label>
         <button id="restart">Restart</button>
         <button id="save">Save</button>
         <button id="load">Load</button>
@@ -45,6 +47,7 @@
         </div>
         <div class="scene-text" id="sceneText">—</div>
         <div class="decision" id="decision"></div>
+        <div class="consequence" id="consequence"></div>
       </section>
 
       <section class="card" id="statusCard">

--- a/pilot_humility_hubris/frontend/style.css
+++ b/pilot_humility_hubris/frontend/style.css
@@ -143,6 +143,16 @@ body {
   width: 100%;
 }
 
+#constellation {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  display: none;
+  pointer-events: none;
+}
+
 /* Top HUD Navigation */
 .hud {
   position: fixed;
@@ -198,6 +208,10 @@ body {
 .pill label {
   color: var(--text-muted); /* Make label more muted */
   font-weight: 500;
+}
+
+.pill input {
+  margin-right: var(--space-xs);
 }
 
 /* Form Controls */
@@ -368,6 +382,14 @@ select:focus {
   padding: var(--space-lg) 0;
   opacity: 0;
   animation: choicesFadeIn 700ms ease-out forwards 300ms; /* Delayed fade in */
+}
+
+.consequence {
+  display: none;
+  margin-top: var(--space-md);
+  font-size: var(--font-size-base);
+  color: var(--text-secondary);
+  min-height: 1.5em;
 }
 
 .choice-button {
@@ -569,6 +591,19 @@ select:focus {
   width: 85%;
   height: 85%;
   overflow: visible; /* Allow adornments to extend slightly */
+}
+
+.archetype-card {
+  text-align: center;
+  padding: var(--space-lg);
+}
+
+.archetype-card h2 {
+  margin-bottom: var(--space-md);
+}
+
+.archetype-card p {
+  margin: var(--space-xs) 0;
 }
 
 .journal {


### PR DESCRIPTION
## Summary
- show text consequences between choices
- add quick mode pacing toggle and ambience canvas toggle
- simplify archetype portrait to a text card

## Testing
- `PYTHONPATH=. pytest pilot_humility_hubris/tests/test_hh_scoring.py`
- `npx --yes html-validate pilot_humility_hubris/frontend/index.html` *(fails: 403 Forbidden)*
- `npx --yes eslint pilot_humility_hubris/frontend/app.js` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c4ebcec83238c219ffa2f34f7b9