### PR TITLE
Add portrait asset pack and centralize style tokens

### DIFF
--- a/pilot_humility_hubris/frontend/assets/README.md
+++ b/pilot_humility_hubris/frontend/assets/README.md
@@ -1,0 +1,15 @@
+# Humility-Hubris Asset Pack
+
+This folder contains the coherent visual language for the prototype.
+
+## Portrait motifs
+
+`portraits/` holds eight minimalist SVG silhouettes sized for 64×64 rendering.
+Each icon uses two flat colors and `currentColor` so the accent hue can be
+applied via CSS.
+
+## Style tokens
+
+Color, typography and motion tokens are centralized in `../style.css`.
+Animations use the shared `--motion-emphasis-duration` and
+`--motion-emphasis-ease` values to keep motion subtle.

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-01.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-01.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M32 2a30 30 0 1 0 0 60 30 30 0 1 0 0-60zm0 44a14 14 0 1 1 0-28 14 14 0 1 1 0 28z"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-02.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-02.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M32 2l30 30-30 30L2 32z"/>
+  <path fill="white" d="M32 12L52 32 32 52 12 32z"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-03.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-03.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M32 4l28 56H4z"/>
+  <circle cx="32" cy="32" r="8" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-04.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-04.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect x="28" y="4" width="8" height="56" fill="currentColor"/>
+  <rect x="4" y="28" width="56" height="8" fill="currentColor"/>
+  <circle cx="32" cy="32" r="10" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-05.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-05.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="32,2 58,16 58,48 32,62 6,48 6,16" fill="currentColor"/>
+  <circle cx="32" cy="32" r="6" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-06.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-06.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="38" cy="32" r="30" fill="currentColor"/>
+  <circle cx="26" cy="32" r="30" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-07.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-07.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 32c8-16 16 16 24 0s16 16 24 0" fill="none" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="52" cy="32" r="4" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/assets/portraits/motif-08.svg
+++ b/pilot_humility_hubris/frontend/assets/portraits/motif-08.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <path fill="currentColor" d="M32 4l9 19 21 3-15 15 4 21-19-10-19 10 4-21-15-15 21-3z"/>
+  <circle cx="32" cy="32" r="5" fill="white"/>
+</svg>

--- a/pilot_humility_hubris/frontend/style.css
+++ b/pilot_humility_hubris/frontend/style.css
@@ -10,6 +10,9 @@
   --bg-sat: 18%;
   --bg-light: 12%;
   --accent: 215, 65%, 54%; /* Cool indigo accent (H, S%, L%) */
+  --color-bg: hsl(var(--bg-hue), var(--bg-sat), var(--bg-light));
+  --color-accent: hsl(var(--accent));
+  --text-accent: var(--color-accent);
 
   /* Enhanced color palette with better contrast */
   --glass: hsla(215, 10%, 100%, 0.06); /* Slight cool tint to glass */
@@ -18,7 +21,6 @@
   --text-primary: hsl(0, 0%, 98%);
   --text-secondary: hsl(0, 0%, 80%);
   --text-muted: hsl(0, 0%, 65%); /* Darker for subtle hints */
-  --text-accent: hsl(var(--accent));
   
   /* Enhanced border system */
   --border-subtle: hsla(0, 0%, 100%, 0.08); /* More subtle */
@@ -33,7 +35,7 @@
   --shadow-accent: 0 6px 18px hsla(var(--accent), 0.35);
   
   /* Typography scale */
-  --font-family-primary: "Inter", ui-sans-serif, system-ui, -apple-system, 
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, 
                          "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-size-xs: 0.7rem;     /* 11.2px */
   --font-size-sm: 0.825rem;    /* 13.2px */
@@ -66,6 +68,8 @@
   --transition-normal: 250ms cubic-bezier(0.4, 0, 0.2, 1);
   --transition-slow: 350ms cubic-bezier(0.4, 0, 0.2, 1);
   --transition-atmosphere: 2000ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  --motion-emphasis-duration: 800ms;
+  --motion-emphasis-ease: cubic-bezier(0.25, 0.46, 0.45, 0.94);
 }
 
 /* ================================
@@ -85,7 +89,7 @@ html {
 body {
   margin: 0;
   height: 100%;
-  font-family: var(--font-family-primary);
+  font-family: var(--font-sans);
   font-size: var(--font-size-base);
   line-height: 1.6;
   color: var(--text-primary);
@@ -647,40 +651,40 @@ select:focus {
     hsla(var(--accent), 0.6), 
     hsla(var(--accent), 0.0)
   );
-  animation: ripple 1200ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  animation: ripple var(--motion-emphasis-duration) var(--motion-emphasis-ease) forwards;
   z-index: 999; /* Ensure it's on top */
 }
 
 .ripple.faint {
   opacity: 0.3;
-  animation: ripple 1600ms cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+  animation: ripple calc(var(--motion-emphasis-duration) * 1.25) var(--motion-emphasis-ease) forwards;
 }
 
 @keyframes ripple {
   from {
-    transform: scale(0.5);
-    opacity: 0.8;
+    transform: scale(0.8);
+    opacity: 0.6;
   }
   to {
-    transform: scale(50);
+    transform: scale(20);
     opacity: 0;
   }
 }
 
 /* Scene Transition (Dream-Walk) */
 .dissolve {
-  animation: dissolve 1000ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  animation: dissolve var(--motion-emphasis-duration) var(--motion-emphasis-ease) both;
 }
 
 @keyframes dissolve {
   0% {
     opacity: 0;
-    filter: blur(16px) hue-rotate(-20deg) brightness(0.7);
-    transform: translateY(30px) scale(0.96);
+    filter: blur(8px) hue-rotate(-10deg) brightness(0.8);
+    transform: translateY(15px) scale(0.98);
   }
   50% {
-    filter: blur(6px) hue-rotate(15deg) brightness(1.1);
-    transform: translateY(-6px) scale(1.02);
+    filter: blur(3px) hue-rotate(8deg) brightness(1.05);
+    transform: translateY(-3px) scale(1.01);
   }
   100% {
     opacity: 1;
@@ -694,17 +698,17 @@ select:focus {
   0%, 100% {
     opacity: 0.8;
     transform: scale(1);
-    filter: drop-shadow(0 0 3px hsla(var(--accent), 0.6));
+    filter: drop-shadow(0 0 2px hsla(var(--accent), 0.4));
   }
   50% {
     opacity: 1;
-    transform: scale(1.08);
-    filter: drop-shadow(0 0 10px hsla(var(--accent), 0.9));
+    transform: scale(1.04);
+    filter: drop-shadow(0 0 6px hsla(var(--accent), 0.7));
   }
 }
 
 .adornment-animation {
-  animation: pulseGlow 3s infinite cubic-bezier(0.4, 0, 0.6, 1);
+  animation: pulseGlow 4s infinite var(--motion-emphasis-ease);
 }
 
 /* ================================


### PR DESCRIPTION
## Summary
- add eight minimalist SVG portrait motifs and asset pack README
- centralize color, typography, and motion tokens in style.css
- soften ripple and dissolve animations to use shared motion tokens

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e3feaa71883239298d9398fe1c758